### PR TITLE
set Wwise generator to use latest Windows SDK by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bugfixes:
 * Only append to table when first value is a float
 * GUI send/receive config for objects in subpatches
 * DPF: also send BPM value to `__hv_dpf_bpm` when transport is not playing
+* Wwise: use latest Windows SDK available locally instead of hardcoded version
 
 0.15.0
 -----

--- a/docs/generators/wwise.md
+++ b/docs/generators/wwise.md
@@ -62,18 +62,15 @@ An appropriate configuration will be selected at compile time based on the numbe
 
 To build Authoring and Engine plugins on Windows you’ll need:
 
-- If using Visual Studio 2019:
+- Visual Studio 2022 with the following components:
   - Desktop development with C++ workload
-  - MSVC v142 - VS 2019 C++ x64/x86 build tools
-  - C++ ATL for latest v142 build tools (x86 & x64)
-  - C++ MFC for latest v142 build tools (x86 & x64)
+  - MSVC v143 - VS 2022 C++ x64/x86 build tools
+  - C++ ATL for latest v143 build tools (x86 & x64)
+  - C++ MFC for latest v143 build tools (x86 & x64)
   - Windows Universal CRT SDK
-  - Windows 10 SDK (10.0.19041.0)
-    - Different version can be specified in a generated
-      PremakePlugin.lua file
-- If using Visual Studio 2022
-  - Requirements are the same as for 2019, but components of version v143 must be installed instead
-  - *Note:* Wwise of version at least 2022.1.5 is required to build plugins with this version of Visual Studio
+  - Windows SDK
+    - Any version that's not "out of support" should work
+    - Different version can be specified in a generated PremakePlugin.lua file
 - Wwise 2022 or later
   - Version 2021 should work, too, but it wasn't tested
   - SDKs with required deployment platforms must be installed through
@@ -102,14 +99,14 @@ Generate Visual Studio project files; note, WWISEROOT environment variable can b
 
 ```cmd
 python "%WWISEROOT%\Scripts\Build\Plugins\wp.py" premake Authoring
-python "%WWISEROOT%\Scripts\Build\Plugins\wp.py" premake Windows_vc160
+python "%WWISEROOT%\Scripts\Build\Plugins\wp.py" premake Windows_vc170
 ```
 
-Build Authoring and Engine plugins in Release configurations; for Visual Studio 2022 replace vc160 with vc170:
+Build Authoring and Engine plugins in Release configurations with for Visual Studio 2022 (vc170):
 
 ```cmd
-python "%WWISEROOT%\Scripts\Build\Plugins\wp.py" build -c Release -x x64 -t vc160 Authoring
-python "%WWISEROOT%\Scripts\Build\Plugins\wp.py" build -c Release -x x64 -t vc160 Windows_vc160
+python "%WWISEROOT%\Scripts\Build\Plugins\wp.py" build -c Release -x x64 -t vc170 Authoring
+python "%WWISEROOT%\Scripts\Build\Plugins\wp.py" build -c Release -x x64 -t vc170 Windows_vc170
 ```
 
 At this point, the plugins should be placed in correct SDK directories and be ready for use in the Authoring app.
@@ -120,7 +117,7 @@ We can go a step further and package the plugins into a bundle that can be insta
 
 ```cmd
 python "%WWISEROOT%\Scripts\Build\Plugins\wp.py" package --version 2022.1.0.1 Authoring
-python "%WWISEROOT%\Scripts\Build\Plugins\wp.py" package --version 2022.1.0.1 Windows_vc160
+python "%WWISEROOT%\Scripts\Build\Plugins\wp.py" package --version 2022.1.0.1 Windows_vc170
 python "%WWISEROOT%\Scripts\Build\Plugins\wp.py" generate-bundle --version 2022.1.0.1
 mkdir Bundle
 copy /y bundle.json Bundle

--- a/hvcc/generators/c2wwise/templates/PremakePlugin.lua
+++ b/hvcc/generators/c2wwise/templates/PremakePlugin.lua
@@ -28,7 +28,7 @@ Plugin.sdk.static.libdirs = {}
 Plugin.sdk.static.defines = {}
 Plugin.sdk.static.custom = function()
    filter "system:Windows"
-      systemversion "10.0.19041.0"
+      systemversion "latest"
 end
 
 Plugin.sdk.shared.includedirs = {}
@@ -43,7 +43,7 @@ Plugin.sdk.shared.libdirs = {}
 Plugin.sdk.shared.defines = {}
 Plugin.sdk.shared.custom = function()
    filter "system:Windows"
-      systemversion "10.0.19041.0"
+      systemversion "latest"
 end
 
 Plugin.authoring.includedirs =
@@ -67,7 +67,7 @@ Plugin.authoring.libdirs = {}
 Plugin.authoring.defines = {}
 Plugin.authoring.custom = function()
    filter "system:Windows"
-      systemversion "10.0.19041.0"
+      systemversion "latest"
 end
 
 return Plugin


### PR DESCRIPTION
Also edited related docs:
- removed VS 2019 as it's very obsolete at this point
- removed explicit Windows SDK suggestion
- if either of these two changes causes inconvenience to someone, then it's probably a pro user that can get help from their team

