### PR TITLE
migrate to pathlib

### DIFF
--- a/docs/generators/custom.md
+++ b/docs/generators/custom.md
@@ -19,6 +19,7 @@ This is `example_hvcc_generator.py`:
 import time
 
 from typing import Dict, Optional
+from pathlib import Path
 
 from hvcc.types.compiler import CompilerResp, ExternInfo, Generator
 from hvcc.types.meta import Meta
@@ -28,8 +29,8 @@ class ExampleHvccGenerator(Generator):
     @classmethod
     def compile(
         cls,
-        c_src_dir: str,
-        out_dir: str,
+        c_src_dir: Path,
+        out_dir: Path,
         externs: ExternInfo,
         patch_name: Optional[str] = None,
         patch_meta: Meta = Meta(),

--- a/docs/mkdocs_hooks.py
+++ b/docs/mkdocs_hooks.py
@@ -1,5 +1,6 @@
-import os
 import re
+
+from pathlib import Path
 
 
 def python_indent(content):
@@ -9,7 +10,7 @@ def python_indent(content):
 
 def on_page_markdown(markdown, page, config, files):
     if page.file.src_path == 'index.md':
-        readme_path = os.path.join(os.path.dirname(config['config_file_path']), 'README.md')
+        readme_path = Path(Path(config['config_file_path']).parent, 'README.md')
         try:
             with open(readme_path, 'r', encoding='utf-8') as f:
                 content = f.read()

--- a/hvcc/compiler.py
+++ b/hvcc/compiler.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2021-2024 Wasted Audio
+# Copyright (C) 2021-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/compiler.py
+++ b/hvcc/compiler.py
@@ -20,7 +20,9 @@ import json
 import os
 import re
 import sys
+
 from typing import Any, List, Dict, Optional
+from pathlib import Path
 
 from hvcc.interpreters.pd2gui import pd2gui
 from hvcc.interpreters.pd2hv import pd2hv
@@ -209,11 +211,11 @@ def load_ext_generator(module_name: str, verbose: bool) -> Optional[Generator]:
 
 
 def compile_dataflow(
-    in_path: str,
-    out_dir: str,
+    in_path: Path,
+    out_dir: Path,
     patch_name: str = "heavy",
-    patch_meta_file: Optional[str] = None,
-    search_paths: Optional[List[str]] = None,
+    patch_meta_file: Optional[Path] = None,
+    search_paths: Optional[List[Path]] = None,
     generators: Optional[List[str]] = None,
     ext_generators: Optional[List[str]] = None,
     verbose: bool = False,
@@ -225,10 +227,10 @@ def compile_dataflow(
     patch_meta = Meta()
 
     # basic error checking on input
-    if os.path.isfile(in_path):
-        if not in_path.endswith((".pd")):
+    if in_path.is_file():
+        if not str(in_path).endswith((".pd")):
             return add_error(results, "Can only process Pd files.")
-    elif os.path.isdir(in_path):
+    elif in_path.is_dir():
         if not os.path.basename("c"):
             return add_error(results, "Can only process c directories.")
     else:
@@ -236,7 +238,7 @@ def compile_dataflow(
 
     # meta-data file
     if patch_meta_file:
-        if os.path.isfile(patch_meta_file):
+        if patch_meta_file.is_file():
             with open(patch_meta_file) as json_file:
                 try:
                     patch_meta_json = json.load(json_file)
@@ -251,7 +253,7 @@ def compile_dataflow(
         print("--> Generating C")
     results.root["pd2hv"] = pd2hv.pd2hv.compile(
         pd_path=in_path,
-        hv_dir=os.path.join(out_dir, "hv"),
+        hv_dir=Path(out_dir, "hv"),
         search_paths=search_paths,
         verbose=verbose)
 
@@ -260,7 +262,7 @@ def compile_dataflow(
             print("--> Generating GUI IR")
         results.root["pd2gui"] = pd2gui.pd2gui.compile(
             pd_path=in_path,
-            ir_dir=os.path.join(out_dir, "ir"),
+            ir_dir=Path(out_dir, "ir"),
             search_paths=search_paths,
             verbose=verbose)
 
@@ -272,9 +274,9 @@ def compile_dataflow(
 
     subst_name = re.sub(r'\W', '_', patch_name)
     results.root["hv2ir"] = hv2ir.hv2ir.compile(
-        hv_file=os.path.join(response.out_dir, response.out_file),
+        hv_file=Path(response.out_dir, response.out_file),
         # ensure that the ir filename has no funky characters in it
-        ir_file=os.path.join(out_dir, "ir", f"{subst_name}.heavy.ir.json"),
+        ir_file=Path(out_dir, "ir", f"{subst_name}.heavy.ir.json"),
         patch_name=patch_name,
         verbose=verbose)
 
@@ -290,14 +292,14 @@ def compile_dataflow(
 
     # get application path
     if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-        application_path = os.path.join(sys._MEIPASS, 'hvcc')
+        application_path = Path(sys._MEIPASS, 'hvcc')
     elif __file__:
-        application_path = os.path.dirname(__file__)
+        application_path = Path(__file__).parent
 
-    c_src_dir = os.path.join(out_dir, "c")
+    c_src_dir = Path(out_dir, "c")
     results.root["ir2c"] = ir2c.ir2c.compile(
-        hv_ir_path=os.path.join(results.root["hv2ir"].out_dir, results.root["hv2ir"].out_file),
-        static_dir=os.path.join(application_path, "generators/ir2c/static"),
+        hv_ir_path=Path(results.root["hv2ir"].out_dir, results.root["hv2ir"].out_file),
+        static_dir=Path(application_path, "generators/ir2c/static"),
         output_dir=c_src_dir,
         externs=externs,
         copyright=copyright,

--- a/hvcc/core/hv2ir/HLangIf.py
+++ b/hvcc/core/hv2ir/HLangIf.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/core/hv2ir/HLangIf.py
+++ b/hvcc/core/hv2ir/HLangIf.py
@@ -16,31 +16,35 @@
 
 # moved to HeavyParser.py because of circular dependency
 
+# from pathlib import Path
 
 # from .HeavyException import HeavyException
 # from .HeavyIrObject import HeavyIrObject
 # from .HeavyLangObject import HeavyLangObject
 
-
 # class HLangIf(HeavyLangObject):
 #     """ Translates HeavyLang object [if] to HeavyIR [if] or [if~].
 #     """
 
-#     def __init__(self, obj_type, args, graph, annotations=None):
-#         HeavyLangObject.__init__(self, "if", args, graph,
-#                                  num_inlets=2,
-#                                  num_outlets=2,
-#                                  annotations=annotations)
+#     def __init__(
+#         self,
+#         obj_type: str,
+#         args: Dict,
+#         graph: HeavyGraph,
+#         annotations: Optional[Dict] = None
+#     ) -> None:
+#         assert obj_type == "if"
+#         super().__init__("if", args, graph, num_inlets=2, num_outlets=2, annotations=annotations)
 
-#     def reduce(self):
+#     def reduce(self) -> Tuple[Set, List]:
 #         if self.has_inlet_connection_format(["cc", "_c", "c_", "__"]):
 #             x = HeavyIrObject("__if", self.args)
 #         elif self.has_inlet_connection_format("ff"):
 #             # TODO(mhroth): implement this
-#             x = HeavyParser.graph_from_file("./hvlib/if~f.hv.json")
+#             x = HeavyParser.graph_from_file(Path("./hvlib/if~f.hv.json"))
 #         elif self.has_inlet_connection_format("ii"):
 #             # TODO(mhroth): implement this
-#             x = HeavyParser.graph_from_file("./hvlib/if~i.hv.json")
+#             x = HeavyParser.graph_from_file(Path("./hvlib/if~i.hv.json"))
 #         else:
 #             fmt = self._get_connection_format(self.inlet_connections)
 #             raise HeavyException(f"Unhandled connection configuration to object [if]: {fmt}")

--- a/hvcc/core/hv2ir/HLangNoise.py
+++ b/hvcc/core/hv2ir/HLangNoise.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/core/hv2ir/HLangNoise.py
+++ b/hvcc/core/hv2ir/HLangNoise.py
@@ -16,9 +16,8 @@
 
 # moved to HeavyParser.py because of circular dependency
 
-
-# import os
 # import random
+# from pathlib import Path
 
 # from .HeavyLangObject import HeavyLangObject
 # from .HeavyParser import HeavyParser
@@ -28,16 +27,19 @@
 #     """ Handles the HeavyLang "noise" object.
 #     """
 
-#     def __init__(self, obj_type, args, graph, annotations=None):
+#     def __init__(
+#         self,
+#         obj_type: str,
+#         args: Dict,
+#         graph: HeavyGraph,
+#         annotations: Optional[Dict] = None
+#     ) -> None:
 #         assert obj_type == "noise"
-#         HeavyLangObject.__init__(self, "noise", args, graph,
-#                                  num_inlets=1,
-#                                  num_outlets=1,
-#                                  annotations=annotations)
+#         super().__init__("noise", args, graph, num_inlets=1, num_outlets=1, annotations=annotations)
 
-#     def reduce(self):
+#     def reduce(self) -> Tuple[Set, List]:
 #         seed = int(random.uniform(1, 2147483647))  # assign a random 32-bit seed
-#         noise_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./hvlib/noise.hv.json")
+#         noise_path = Path(Path(__file__).parent, "./hvlib/noise.hv.json")
 #         x = HeavyParser.graph_from_file(noise_path, graph_args={"seed": seed})
 #         x.reduce()
 #         # TODO(mhroth): deal with control input

--- a/hvcc/core/hv2ir/HeavyGraph.py
+++ b/hvcc/core/hv2ir/HeavyGraph.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023-2024 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/core/hv2ir/HeavyGraph.py
+++ b/hvcc/core/hv2ir/HeavyGraph.py
@@ -14,10 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import re
+
 from collections import Counter
 from typing import Optional, Union, Dict, List, Set, Tuple
+from pathlib import Path
 
 from .BufferPool import BufferPool
 from .Connection import Connection
@@ -45,7 +46,7 @@ class HeavyGraph(HeavyIrObject):
         self,
         graph: Optional['HeavyGraph'] = None,
         graph_args: Optional[Dict] = None,
-        file: str = "",
+        file: Path = Path(),
         xname: str = "heavy"
     ) -> None:
         # zero inlets and outlets until inlet/outlet objects are declared
@@ -321,7 +322,7 @@ class HeavyGraph(HeavyIrObject):
             # NOTE(dromer): we should never get here
             raise Exception
 
-    def find_path_for_abstraction(self, obj_type: str) -> Optional[str]:
+    def find_path_for_abstraction(self, obj_type: str) -> Optional[Path]:
         """ Travels up the graph heirarchy looking for a file path to an abstraction.
             Returns None if no abstraction is found.
         """
@@ -857,9 +858,9 @@ class HeavyGraph(HeavyIrObject):
     def __repr__(self) -> str:
         if self.xname is not None:
             # TODO(mhroth): does not handle nested subgraph
-            return f"__graph.{self.id}({os.path.basename(self.file)}/{self.xname})"
+            return f"__graph.{self.id}({self.file.name}/{self.xname})"
         else:
-            return f"__graph.{self.id}({os.path.basename(self.file)})"
+            return f"__graph.{self.id}({self.file.name})"
 
     #
     # Intermediate Representation generators

--- a/hvcc/core/hv2ir/HeavyIrObject.py
+++ b/hvcc/core/hv2ir/HeavyIrObject.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023-2024 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/core/hv2ir/HeavyIrObject.py
+++ b/hvcc/core/hv2ir/HeavyIrObject.py
@@ -15,9 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
-import os
 
 from typing import Dict, List, Optional, TYPE_CHECKING
+from pathlib import Path
+
 
 from .Connection import Connection
 from .HeavyException import HeavyException
@@ -39,7 +40,7 @@ class HeavyIrObject(HeavyLangObject):
     """
 
     # load the HeavyIR object definitions
-    with open(os.path.join(os.path.dirname(__file__), "../json/heavy.ir.json"), "r") as f:
+    with open(Path(Path(__file__).parent, "../json/heavy.ir.json"), "r") as f:
         __HEAVY_OBJS_IR_DICT = HeavyIRType(**json.load(f)).root
 
     def __init__(

--- a/hvcc/core/hv2ir/HeavyLangObject.py
+++ b/hvcc/core/hv2ir/HeavyLangObject.py
@@ -16,12 +16,12 @@
 
 import decimal
 import json
-import os
 import random
 import string
 
 from struct import unpack, pack
 from typing import Optional, Union, List, Dict, Any, TYPE_CHECKING
+from pathlib import Path
 
 from .Connection import Connection
 from .HeavyException import HeavyException
@@ -42,7 +42,7 @@ class HeavyLangObject:
     __ID_CHARS = string.ascii_letters + string.digits
 
     # load the Heavy object definitions
-    with open(os.path.join(os.path.dirname(__file__), "../json/heavy.lang.json"), "r") as f:
+    with open(Path(Path(__file__).parent, "../json/heavy.lang.json"), "r") as f:
         _HEAVY_LANG_DICT = HeavyLangType(**json.load(f)).root
 
     def __init__(

--- a/hvcc/core/hv2ir/HeavyLangObject.py
+++ b/hvcc/core/hv2ir/HeavyLangObject.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023-2024 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/core/hv2ir/HeavyParser.py
+++ b/hvcc/core/hv2ir/HeavyParser.py
@@ -16,9 +16,9 @@
 
 import json
 import random
-import os
 
 from typing import Any, Dict, List, Optional, Set, Tuple
+from pathlib import Path
 
 from .HIrConvolution import HIrConvolution
 from .HIrExpr import HIrExpr
@@ -65,7 +65,7 @@ class HeavyParser:
     @classmethod
     def graph_from_file(
         cls,
-        hv_file: str,
+        hv_file: Path,
         graph: Optional[HeavyGraph] = None,
         graph_args: Optional[Dict] = None,
         path_stack: Optional[set] = None,
@@ -80,7 +80,7 @@ class HeavyParser:
             It prevents infinite recursion when reading many abstractions deep.
         """
         # ensure that we have an absolute path to the hv_file
-        hv_file = os.path.abspath(os.path.expanduser(hv_file))
+        hv_file = hv_file.expanduser().absolute()
 
         # copy the path stack such that no changes are made to the calling stack
         path_stack = path_stack or set()
@@ -98,7 +98,7 @@ class HeavyParser:
     @classmethod
     def graph_from_object(
         cls,
-        hv_file: str,
+        hv_file: Path,
         json_heavy: Dict,
         path_stack: set,
         graph: Optional[HeavyGraph] = None,
@@ -134,7 +134,7 @@ class HeavyParser:
         # add the import paths to the global vars
         g.local_vars.add_import_paths(json_heavy.get("imports", []))
         # add the file's relative directory to global vars
-        g.local_vars.add_import_paths([os.path.dirname(hv_file)])
+        g.local_vars.add_import_paths([hv_file.parent])
 
         # instantiate all objects
         try:
@@ -239,10 +239,10 @@ class HLangIf(HeavyLangObject):
             x = HeavyIrObject("__if", self.args)
         elif self.has_inlet_connection_format("ff"):
             # TODO(mhroth): implement this
-            x = HeavyParser.graph_from_file("./hvlib/if~f.hv.json")
+            x = HeavyParser.graph_from_file(Path("./hvlib/if~f.hv.json"))
         elif self.has_inlet_connection_format("ii"):
             # TODO(mhroth): implement this
-            x = HeavyParser.graph_from_file("./hvlib/if~i.hv.json")
+            x = HeavyParser.graph_from_file(Path("./hvlib/if~i.hv.json"))
         else:
             fmt = self._get_connection_format(self.inlet_connections)
             raise HeavyException(f"Unhandled connection configuration to object [if]: {fmt}")
@@ -266,7 +266,7 @@ class HLangNoise(HeavyLangObject):
 
     def reduce(self) -> Tuple[Set, List]:
         seed = int(random.uniform(1, 2147483647))  # assign a random 32-bit seed
-        noise_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./hvlib/noise.hv.json")
+        noise_path = Path(Path(__file__).parent, "./hvlib/noise.hv.json")
         x = HeavyParser.graph_from_file(noise_path, graph_args={"seed": seed})
         x.reduce()
         # TODO(mhroth): deal with control input

--- a/hvcc/core/hv2ir/HeavyParser.py
+++ b/hvcc/core/hv2ir/HeavyParser.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023-2024 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/core/hv2ir/LocalVars.py
+++ b/hvcc/core/hv2ir/LocalVars.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/core/hv2ir/LocalVars.py
+++ b/hvcc/core/hv2ir/LocalVars.py
@@ -17,6 +17,7 @@
 import os
 from collections import defaultdict
 from typing import Optional, Union, Dict, List
+from pathlib import Path
 
 from .HeavyException import HeavyException
 from .HeavyLangObject import HeavyLangObject
@@ -36,14 +37,14 @@ class LocalVars:
         # the list of globally declared paths
         self.declared_paths = [stdlib_dir]  # initialise with the standard library directory
 
-    def find_path_for_abstraction(self, name: str) -> Optional[str]:
+    def find_path_for_abstraction(self, name: str) -> Optional[Path]:
         # the file name based on the abstraction name
         file_name = f"{name}.hv.json"
 
         # iterate in order through the declared paths in order to find the file
         for d in self.declared_paths:
-            file_path = os.path.join(d, file_name)
-            if os.path.exists(file_path):
+            file_path = Path(d, file_name)
+            if file_path.exists():
                 return file_path  # if a matching abstraction is found, return the path
         return None  # otherwise return None
 

--- a/hvcc/core/hv2ir/hv2ir.py
+++ b/hvcc/core/hv2ir/hv2ir.py
@@ -20,6 +20,7 @@ import os
 import time
 
 from typing import Optional
+from pathlib import Path
 
 from hvcc.core.hv2ir.HeavyException import HeavyException
 from hvcc.core.hv2ir.HeavyParser import HeavyParser
@@ -32,8 +33,8 @@ class hv2ir:
     @classmethod
     def compile(
         cls,
-        hv_file: str,
-        ir_file: str,
+        hv_file: Path,
+        ir_file: Path,
         patch_name: Optional[str] = None,
         verbose: bool = False
     ) -> CompilerResp:
@@ -45,8 +46,8 @@ class hv2ir:
         # keep track of the total compile time
         tick = time.time()
 
-        hv_file = os.path.abspath(os.path.expanduser(hv_file))
-        ir_file = os.path.abspath(os.path.expanduser(ir_file))
+        hv_file = hv_file.expanduser().absolute()
+        ir_file = ir_file.expanduser().absolute()
 
         try:
             # parse heavy file
@@ -61,10 +62,10 @@ class hv2ir:
                     errors=[CompilerMsg(message=e.message)],
                     warnings=[]
                 ),
-                in_file=os.path.basename(hv_file),
-                in_dir=os.path.dirname(hv_file),
-                out_file=os.path.basename(ir_file),
-                out_dir=os.path.dirname(ir_file)
+                in_file=hv_file,
+                in_dir=hv_file.parent,
+                out_file=ir_file,
+                out_dir=ir_file.parent
             )
 
         try:
@@ -75,8 +76,8 @@ class hv2ir:
             hv_graph.prepare()
 
             # ensure that the output directory exists
-            if not os.path.exists(os.path.dirname(ir_file)):
-                os.makedirs(os.path.dirname(ir_file))
+            if not ir_file.parent.exists():
+                os.makedirs(ir_file.parent)
 
             # generate Heavy.IR
             ir = hv_graph.to_ir()
@@ -90,10 +91,10 @@ class hv2ir:
                     errors=[CompilerMsg(message=e.message)],
                     warnings=[]
                 ),
-                in_file=os.path.basename(hv_file),
-                in_dir=os.path.dirname(hv_file),
-                out_file=os.path.basename(ir_file),
-                out_dir=os.path.dirname(ir_file),
+                in_file=hv_file,
+                in_dir=hv_file.parent,
+                out_file=ir_file,
+                out_dir=ir_file.parent,
                 obj_counter=hv_counter
             )
 
@@ -119,10 +120,10 @@ class hv2ir:
             stage="hv2ir",
             compile_time=time.time() - tick,  # record the total compile time
             notifs=hv_graph.get_notices(),
-            in_file=os.path.basename(hv_file),
-            in_dir=os.path.dirname(hv_file),
-            out_file=os.path.basename(ir_file),
-            out_dir=os.path.dirname(ir_file),
+            in_file=hv_file,
+            in_dir=hv_file.parent,
+            out_file=ir_file,
+            out_dir=ir_file.parent,
             obj_counter=hv_counter,
             ir=ir
         )

--- a/hvcc/core/hv2ir/hv2ir.py
+++ b/hvcc/core/hv2ir/hv2ir.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023-2024 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/generators/c2daisy/c2daisy.py
+++ b/hvcc/generators/c2daisy/c2daisy.py
@@ -1,9 +1,9 @@
 import jinja2
-import os
 import shutil
 import time
 
 from typing import Any, Dict, Optional
+from pathlib import Path
 
 from ..copyright import copyright_manager
 from .parameters import parse_parameters, display_parameters, display_processor
@@ -33,8 +33,8 @@ class c2daisy(Generator):
     @classmethod
     def compile(
         cls,
-        c_src_dir: str,
-        out_dir: str,
+        c_src_dir: Path,
+        out_dir: Path,
         externs: ExternInfo,
         patch_name: Optional[str] = None,
         patch_meta: Meta = Meta(),
@@ -47,7 +47,7 @@ class c2daisy(Generator):
         tick = time.time()
         warnings = []
 
-        out_dir = os.path.join(out_dir, "daisy")
+        out_dir = Path(out_dir, "daisy")
 
         daisy_meta: Daisy = patch_meta.daisy
         board = daisy_meta.board
@@ -56,19 +56,19 @@ class c2daisy(Generator):
 
         try:
             # ensure that the output directory does not exist
-            out_dir = os.path.abspath(out_dir)
-            if os.path.exists(out_dir):
+            out_dir = out_dir.absolute()
+            if out_dir.exists():
                 shutil.rmtree(out_dir)
 
             # copy over static files
-            shutil.copytree(os.path.join(os.path.dirname(__file__), "static"), out_dir)
+            shutil.copytree(Path(Path(__file__).parent, "static"), out_dir)
 
             # copy over generated C source files
-            source_dir = os.path.join(out_dir, "source")
+            source_dir = Path(out_dir, "source")
             shutil.copytree(c_src_dir, source_dir)
 
             if daisy_meta.board_file is not None:
-                header, board_info = generate_header_from_file(daisy_meta.board_file)
+                header, board_info = generate_header_from_file(Path(daisy_meta.board_file))
                 display_params = display_parameters(daisy_meta.board_file)
             else:
                 header, board_info = generate_header_from_name(board)
@@ -134,13 +134,13 @@ class c2daisy(Generator):
 
             component_glue['copyright'] = copyright_c
 
-            daisy_h_path = os.path.join(source_dir, f"HeavyDaisy_{patch_name}.hpp")
+            daisy_h_path = Path(source_dir, f"HeavyDaisy_{patch_name}.hpp")
             with open(daisy_h_path, "w") as f:
                 f.write(header)
 
-            loader = jinja2.FileSystemLoader(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates'))
+            loader = jinja2.FileSystemLoader(Path(Path(__file__).parent, 'templates'))
             env = jinja2.Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
-            daisy_cpp_path = os.path.join(source_dir, f"HeavyDaisy_{patch_name}.cpp")
+            daisy_cpp_path = Path(source_dir, f"HeavyDaisy_{patch_name}.cpp")
 
             rendered_cpp = env.get_template('HeavyDaisy.cpp').render(component_glue)
             with open(daisy_cpp_path, 'w') as f:
@@ -160,7 +160,7 @@ class c2daisy(Generator):
             makefile_replacements['debug_printing'] = daisy_meta.debug_printing
 
             rendered_makefile = env.get_template('Makefile').render(makefile_replacements)
-            with open(os.path.join(source_dir, "Makefile"), "w") as f:
+            with open(Path(source_dir, "Makefile"), "w") as f:
                 f.write(rendered_makefile)
 
             # ======================================================================================
@@ -172,7 +172,7 @@ class c2daisy(Generator):
                 ),
                 in_dir=c_src_dir,
                 out_dir=out_dir,
-                out_file=os.path.basename(daisy_h_path),
+                out_file=daisy_h_path,
                 compile_time=time.time() - tick
             )
 

--- a/hvcc/generators/c2daisy/c2daisy.py
+++ b/hvcc/generators/c2daisy/c2daisy.py
@@ -1,3 +1,18 @@
+# Copyright (C) 2021-2026 Wasted Audio
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import jinja2
 import shutil
 import time

--- a/hvcc/generators/c2daisy/json2daisy/LICENSE.md
+++ b/hvcc/generators/c2daisy/json2daisy/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2021 Electrosmith
+Copyright (c) 2025-2026 Wasted Audio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/hvcc/generators/c2daisy/json2daisy/json2daisy.py
+++ b/hvcc/generators/c2daisy/json2daisy/json2daisy.py
@@ -1,19 +1,19 @@
 import jinja2
 import json
-import os
 
 from importlib import resources
 from typing import Optional
+from pathlib import Path
 
 
-def map_load(pair: list, json_defs_file: str):
+def map_load(pair: list, json_defs_file: Path):
     """
     Helper for loading and processing the definitions, component list, etc
     """
 
     # load the default components
-    comp_string = resources.files(__package__).joinpath(json_defs_file).read_text()
-    component_defs = json.loads(comp_string)
+    comp_string = Path(Path(__file__).parent, json_defs_file)
+    component_defs = json.loads(comp_string.read_bytes())
 
     pair[1]['name'] = pair[0]
 
@@ -165,9 +165,9 @@ def generate_header(board_description_dict: dict) -> 'tuple[str, dict]':
         parents[key]['is_parent'] = True
     components.update(parents)
 
-    seed_defs = os.path.join("resources", 'component_defs.json')
-    patchsm_defs = os.path.join("resources", 'component_defs_patchsm.json')
-    petalsm_defs = os.path.join("resources", 'component_defs_petalsm.json')
+    seed_defs = Path("resources", 'component_defs.json')
+    patchsm_defs = Path("resources", 'component_defs_patchsm.json')
+    petalsm_defs = Path("resources", 'component_defs_petalsm.json')
     definitions = {'seed': seed_defs, 'patch_sm': patchsm_defs, 'petal_125b_sm': petalsm_defs}
     som = target.get('som', 'seed')
 
@@ -227,8 +227,8 @@ def generate_header(board_description_dict: dict) -> 'tuple[str, dict]':
         components, 'component', ['AnalogControl', 'AnalogControlBipolar'],
         'map_init', key_exclude='default', match_exclude=True)
 
-    comp_string = resources.files(__package__).joinpath(json_defs_file).read_text()
-    definitions_dict = json.loads(comp_string)
+    comp_string = Path(Path(__file__).parent, json_defs_file)
+    definitions_dict = json.loads(comp_string.read_bytes())
 
     for name in definitions_dict:
         if name not in ('AnalogControl', 'AnalogControlBipolar', 'CD4051'):
@@ -292,7 +292,7 @@ def generate_header(board_description_dict: dict) -> 'tuple[str, dict]':
     # rendered_header = env.get_template('daisy.h').render(replacements)
 
     # This following works, but is really annoying
-    header_str = resources.files(__package__).joinpath(os.path.join('templates', 'daisy.h')).read_text()
+    header_str = Path(Path(__file__).parent, Path('templates', 'daisy.h')).read_text()
     header_env = jinja2.Environment(
         loader=jinja2.BaseLoader(),
         trim_blocks=True,
@@ -327,7 +327,7 @@ def generate_header(board_description_dict: dict) -> 'tuple[str, dict]':
     return rendered_header, board_info
 
 
-def generate_header_from_file(description_file: str) -> 'tuple[str, dict]':
+def generate_header_from_file(description_file: Path) -> 'tuple[str, dict]':
     """
     Generate a C++ Daisy board header from a JSON description file.
 
@@ -358,9 +358,9 @@ def generate_header_from_name(board_name: str) -> 'tuple[str, dict]':
     """
 
     try:
-        description_file = os.path.join('resources', f'{board_name}.json')
-        daisy_description = resources.files(__package__).joinpath(description_file).read_text()
-        daisy_description_dict = json.loads(daisy_description)
+        description_file = Path('resources', f'{board_name}.json')
+        daisy_description = Path(Path(__file__).parent, description_file)
+        daisy_description_dict = json.loads(daisy_description.read_bytes())
     except FileNotFoundError:
         raise FileNotFoundError(f'Unknown Daisy board   "{board_name}"')
 

--- a/hvcc/generators/c2dpf/c2dpf.py
+++ b/hvcc/generators/c2dpf/c2dpf.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2024 Wasted Audio
+# Copyright (C) 2021-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/generators/c2dpf/c2dpf.py
+++ b/hvcc/generators/c2dpf/c2dpf.py
@@ -13,11 +13,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
+import jinja2
 import shutil
 import time
-import jinja2
+
 from typing import Optional
+from pathlib import Path
 
 from ..copyright import copyright_manager
 from ..filters import filter_uniqueid
@@ -34,8 +35,8 @@ class c2dpf(Generator):
     @classmethod
     def compile(
         cls,
-        c_src_dir: str,
-        out_dir: str,
+        c_src_dir: Path,
+        out_dir: Path,
         externs: ExternInfo,
         patch_name: Optional[str] = None,
         patch_meta: Meta = Meta(),
@@ -47,7 +48,7 @@ class c2dpf(Generator):
 
         tick = time.time()
 
-        out_dir = os.path.join(out_dir, "plugin")
+        out_dir = Path(out_dir, "plugin")
         receiver_list = externs.parameters.inParam
         sender_list = externs.parameters.outParam
 
@@ -58,16 +59,16 @@ class c2dpf(Generator):
 
         try:
             # ensure that the output directory does not exist
-            out_dir = os.path.abspath(out_dir)
-            if os.path.exists(out_dir):
+            out_dir = out_dir.absolute()
+            if out_dir.exists():
                 shutil.rmtree(out_dir)
 
             # copy over static files
-            shutil.copytree(os.path.join(os.path.dirname(__file__), "static"), out_dir)
-            shutil.copy(os.path.join(os.path.dirname(__file__), "static/README.md"), f'{out_dir}/../')
+            shutil.copytree(Path(Path(__file__).parent, "static"), out_dir)
+            shutil.copy(Path(Path(__file__).parent, "static/README.md"), f'{out_dir}/../')
 
             # copy over generated C source files
-            source_dir = os.path.join(out_dir, "source")
+            source_dir = Path(out_dir, "source")
             shutil.copytree(c_src_dir, source_dir)
 
             # initialize the jinja template environment
@@ -75,10 +76,10 @@ class c2dpf(Generator):
             env.filters["uniqueid"] = filter_uniqueid
 
             env.loader = jinja2.FileSystemLoader(
-                os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates"))
+                Path(Path(__file__).parent, "templates"))
 
             # generate DPF wrapper from template
-            dpf_h_path = os.path.join(source_dir, f"HeavyDPF_{patch_name}.hpp")
+            dpf_h_path = Path(source_dir, f"HeavyDPF_{patch_name}.hpp")
             with open(dpf_h_path, "w") as f:
                 f.write(env.get_template("HeavyDPF.hpp").render(
                     name=patch_name,
@@ -89,7 +90,7 @@ class c2dpf(Generator):
                     receivers=receiver_list,
                     senders=sender_list,
                     copyright=copyright_c))
-            dpf_cpp_path = os.path.join(source_dir, f"HeavyDPF_{patch_name}.cpp")
+            dpf_cpp_path = Path(source_dir, f"HeavyDPF_{patch_name}.cpp")
             with open(dpf_cpp_path, "w") as f:
                 f.write(env.get_template("HeavyDPF.cpp").render(
                     name=patch_name,
@@ -102,7 +103,7 @@ class c2dpf(Generator):
                     pool_sizes_kb=externs.memoryPoolSizesKb,
                     copyright=copyright_c))
             if dpf_meta.enable_ui:
-                dpf_ui_path = os.path.join(source_dir, f"HeavyDPF_{patch_name}_UI.cpp")
+                dpf_ui_path = Path(source_dir, f"HeavyDPF_{patch_name}_UI.cpp")
                 with open(dpf_ui_path, "w") as f:
                     f.write(env.get_template("HeavyDPF_UI.cpp").render(
                         name=patch_name,
@@ -111,7 +112,7 @@ class c2dpf(Generator):
                         receivers=receiver_list,
                         senders=sender_list,
                         copyright=copyright_c))
-            dpf_h_path = os.path.join(source_dir, "DistrhoPluginInfo.h")
+            dpf_h_path = Path(source_dir, "DistrhoPluginInfo.h")
             with open(dpf_h_path, "w") as f:
                 f.write(env.get_template("DistrhoPluginInfo.h").render(
                     name=patch_name,
@@ -123,7 +124,7 @@ class c2dpf(Generator):
                     copyright=copyright_c))
 
             # plugin makefile
-            with open(os.path.join(source_dir, "Makefile"), "w") as f:
+            with open(Path(source_dir, "Makefile"), "w") as f:
                 f.write(env.get_template("Makefile_plugin").render(
                     name=patch_name,
                     meta=dpf_meta,
@@ -131,7 +132,7 @@ class c2dpf(Generator):
                     dpf_path=dpf_path))
 
             # project makefile
-            with open(os.path.join(source_dir, "../../Makefile"), "w") as f:
+            with open(Path(source_dir, "../../Makefile"), "w") as f:
                 f.write(env.get_template("Makefile_project").render(
                     name=patch_name,
                     meta=dpf_meta,
@@ -141,7 +142,7 @@ class c2dpf(Generator):
                 stage="c2dpf",
                 in_dir=c_src_dir,
                 out_dir=out_dir,
-                out_file=os.path.basename(dpf_h_path),
+                out_file=dpf_h_path,
                 compile_time=time.time() - tick
             )
 

--- a/hvcc/generators/c2fmod/c2fmod.py
+++ b/hvcc/generators/c2fmod/c2fmod.py
@@ -1,5 +1,5 @@
 # Heavy Compiler Collection
-# Copyright (C) 2024 Wasted Audio
+# Copyright (C) 2024-2026 Wasted Audio
 #
 # SPDX-License-Identifier: GPL-3.0-only
 

--- a/hvcc/generators/c2fmod/c2fmod.py
+++ b/hvcc/generators/c2fmod/c2fmod.py
@@ -9,6 +9,7 @@ import shutil
 import time
 
 from typing import Optional
+from pathlib import Path
 
 from hvcc.interpreters.pd2hv.NotificationEnum import NotificationEnum
 from hvcc.types.compiler import Generator, CompilerResp, CompilerNotif, CompilerMsg, ExternInfo
@@ -23,8 +24,8 @@ class c2fmod(Generator):
     @classmethod
     def compile(
         cls,
-        c_src_dir: str,
-        out_dir: str,
+        c_src_dir: Path,
+        out_dir: Path,
         externs: ExternInfo,
         patch_name: Optional[str] = None,
         patch_meta: Meta = Meta(),
@@ -45,10 +46,10 @@ class c2fmod(Generator):
 
         copyright_c = copyright_manager.get_copyright_for_c(copyright)
 
-        templates_dir = os.path.join(os.path.dirname(__file__), "templates")
+        templates_dir = Path(os.path.dirname(__file__), "templates")
         is_source_plugin = num_input_channels == 0
 
-        out_dir = os.path.join(out_dir, "fmod")
+        out_dir = Path(out_dir, "fmod")
         if not os.path.exists(out_dir):
             os.makedirs(out_dir)
 
@@ -59,8 +60,8 @@ class c2fmod(Generator):
 
         try:
 
-            patch_src_dir = os.path.join(out_dir, "include", "Heavy")
-            if os.path.exists(patch_src_dir):
+            patch_src_dir = Path(out_dir, "include", "Heavy")
+            if patch_src_dir.exists():
                 shutil.rmtree(patch_src_dir)
             shutil.copytree(c_src_dir, patch_src_dir)
 
@@ -69,14 +70,15 @@ class c2fmod(Generator):
             src_ext_list = ["h", "hpp", "c", "cpp", "js", "md", "txt"]
 
             for f in env.list_templates(extensions=src_ext_list):
-                file_dir = os.path.join(out_dir, os.path.dirname(f))
-                file_name = os.path.basename(f)
+                file = Path(f)
+                file_dir = Path(out_dir, file.parent)
+                file_name = f
 
                 file_name = file_name.replace("{{name}}", patch_name)
-                file_path = os.path.join(file_dir, file_name)
+                file_path = Path(file_dir, file_name)
 
-                if not os.path.exists(os.path.dirname(file_path)):
-                    os.makedirs(os.path.dirname(file_path))
+                if not file_path.parent.exists():
+                    os.makedirs(file_path.parent)
 
                 with open(file_path, "w") as g:
                     g.write(env.get_template(f).render(

--- a/hvcc/generators/c2fmod/c2fmod.py
+++ b/hvcc/generators/c2fmod/c2fmod.py
@@ -46,12 +46,12 @@ class c2fmod(Generator):
 
         copyright_c = copyright_manager.get_copyright_for_c(copyright)
 
-        templates_dir = Path(os.path.dirname(__file__), "templates")
+        templates_dir = Path(Path(__file__).parent, "templates")
         is_source_plugin = num_input_channels == 0
 
         out_dir = Path(out_dir, "fmod")
-        if not os.path.exists(out_dir):
-            os.makedirs(out_dir)
+        if not out_dir.exists():
+            out_dir.mkdir(parents=True)
 
         env = jinja2.Environment()
         env.loader = jinja2.FileSystemLoader(
@@ -78,7 +78,7 @@ class c2fmod(Generator):
                 file_path = Path(file_dir, file_name)
 
                 if not file_path.parent.exists():
-                    os.makedirs(file_path.parent)
+                    file_path.parent.mkdir(parents=True)
 
                 with open(file_path, "w") as g:
                     g.write(env.get_template(f).render(

--- a/hvcc/generators/c2js/c2js.py
+++ b/hvcc/generators/c2js/c2js.py
@@ -21,6 +21,7 @@ import jinja2
 
 from shutil import which
 from typing import Optional
+from pathlib import Path
 
 from hvcc.core.hv2ir.HeavyException import HeavyException
 from ..copyright import copyright_manager
@@ -67,16 +68,16 @@ class c2js(Generator):
     @classmethod
     def run_emscripten(
         cls,
-        c_src_dir: str,
-        out_dir: str,
+        c_src_dir: Path,
+        out_dir: Path,
         patch_name: str,
         output_name: str,
-        post_js_path: str,
+        post_js_path: Path,
         should_modularize: int,
         environment: str,
-        pre_js_path: str = "",
+        pre_js_path: Path = Path(),
         binaryen_async: int = 1
-    ) -> str:
+    ) -> Path:
         """Run the emcc command to compile C source files to a javascript library.
         """
 
@@ -98,8 +99,8 @@ class c2js(Generator):
             "-Wall"
         ]
 
-        c_src_paths = [os.path.join(c_src_dir, c) for c in os.listdir(c_src_dir) if c.endswith((".c"))]
-        cpp_src_paths = [os.path.join(c_src_dir, cpp) for cpp in os.listdir(c_src_dir) if cpp.endswith((".cpp"))]
+        c_src_paths = [Path(c_src_dir, c) for c in os.listdir(c_src_dir) if c.endswith((".c"))]
+        cpp_src_paths = [Path(c_src_dir, cpp) for cpp in os.listdir(c_src_dir) if cpp.endswith((".cpp"))]
         obj_paths = []
         cmd = ""
 
@@ -121,7 +122,7 @@ class c2js(Generator):
         hv_api_defs = ", ".join([f"\"{x.format(patch_name)}\"" for x in cls.__HV_API])
 
         # output path
-        wasm_js_path = os.path.join(out_dir, f"{output_name}.js")
+        wasm_js_path = Path(out_dir, f"{output_name}.js")
 
         linker_flags = [
             "-O3",
@@ -139,7 +140,7 @@ class c2js(Generator):
             "--post-js", post_js_path
         ]
 
-        if len(pre_js_path):
+        if pre_js_path != Path():
             linker_flags = linker_flags + [
                 "--pre-js", pre_js_path
             ]
@@ -162,8 +163,8 @@ class c2js(Generator):
     @classmethod
     def compile(
         cls,
-        c_src_dir: str,
-        out_dir: str,
+        c_src_dir: Path,
+        out_dir: Path,
         externs: ExternInfo,
         patch_name: Optional[str] = None,
         patch_meta: Meta = Meta(),
@@ -183,27 +184,27 @@ class c2js(Generator):
         midi_list = externs.midi.inMidi
         midi_out_list = externs.midi.outMidi
 
-        out_dir = os.path.join(out_dir, "js")
+        out_dir = Path(out_dir, "js")
         patch_name = patch_name or "heavy"
 
         copyright_js = copyright_manager.get_copyright_for_c(copyright)
         copyright_html = copyright_manager.get_copyright_for_xml(copyright)
 
-        if not os.path.exists(out_dir):
+        if not out_dir.exists():
             os.makedirs(out_dir)
-        out_dir = os.path.abspath(out_dir)
+        out_dir = out_dir.absolute()
 
         try:
             # initialise the jinja template environment
             env = jinja2.Environment()
-            env.loader = jinja2.FileSystemLoader(os.path.join(
-                os.path.dirname(__file__),
+            env.loader = jinja2.FileSystemLoader(Path(
+                Path(__file__).parent,
                 "template"))
 
             # generate heavy js wrapper from template
             # Note: this file will be incorporated into the emscripten output
             # and removed afterwards
-            post_js_path = os.path.join(out_dir, "hv_wrapper.js")
+            post_js_path = Path(out_dir, "hv_wrapper.js")
             with open(post_js_path, "w") as f:
                 f.write(env.get_template("hv_wrapper.js").render(
                     name=patch_name,
@@ -222,10 +223,10 @@ class c2js(Generator):
             # delete temporary files
             os.remove(post_js_path)
 
-            js_out_file = os.path.basename(js_path)
+            js_out_file = js_path
 
             # generate index.html from template
-            with open(os.path.join(out_dir, "index.html"), "w") as f:
+            with open(Path(out_dir, "index.html"), "w") as f:
                 f.write(env.get_template("index.html").render(
                     name=patch_name,
                     includes=[f"./{js_out_file}"],
@@ -240,7 +241,7 @@ class c2js(Generator):
             # generate heavy js worklet from template
             # Note: this file will be incorporated into the emscripten output
             # and removed afterwards
-            post_js_path = os.path.join(out_dir, "hv_worklet.js")
+            post_js_path = Path(out_dir, "hv_worklet.js")
             with open(post_js_path, "w") as f:
                 f.write(env.get_template("hv_worklet.js").render(
                     name=patch_name,
@@ -248,7 +249,7 @@ class c2js(Generator):
                     externs=externs,
                     pool_sizes_kb=externs.memoryPoolSizesKb))
 
-            pre_js_path = os.path.join(out_dir, "hv_worklet_start.js")
+            pre_js_path = Path(out_dir, "hv_worklet_start.js")
             with open(pre_js_path, "w") as f:
                 f.write(env.get_template("hv_worklet_start.js").render(
                     name=patch_name,

--- a/hvcc/generators/c2js/c2js.py
+++ b/hvcc/generators/c2js/c2js.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2021-2024 Wasted Audio
+# Copyright (C) 2021-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/generators/c2owl/c2owl.py
+++ b/hvcc/generators/c2owl/c2owl.py
@@ -1,5 +1,3 @@
-# import datetime
-import os
 import shutil
 import time
 import jinja2
@@ -101,13 +99,12 @@ class c2owl(Generator):
             shutil.copytree(c_src_dir, out_dir)
 
             # copy over deps
-            shutil.copytree(Path(os.path.dirname(__file__), "deps"), out_dir, dirs_exist_ok=True)
+            shutil.copytree(Path(Path(__file__).parent, "deps"), out_dir, dirs_exist_ok=True)
 
             # initialize the jinja template environment
             env = jinja2.Environment()
 
-            env.loader = jinja2.FileSystemLoader(
-                Path(os.path.dirname(os.path.abspath(__file__)), "templates"))
+            env.loader = jinja2.FileSystemLoader(Path(Path(__file__).parent), "templates")
 
             # construct jdata from ir
             ir_dir = Path(c_src_dir, "../ir")

--- a/hvcc/generators/c2owl/c2owl.py
+++ b/hvcc/generators/c2owl/c2owl.py
@@ -4,7 +4,9 @@ import shutil
 import time
 import jinja2
 import json
+
 from typing import List, Optional
+from pathlib import Path
 
 import hvcc.core.hv2ir.HeavyLangObject as HeavyLangObject
 from ..copyright import copyright_manager
@@ -24,7 +26,7 @@ class c2owl(Generator):
     """
 
     @classmethod
-    def make_jdata(cls, patch_ir: str) -> List:
+    def make_jdata(cls, patch_ir: Path) -> List:
         jdata = list()
 
         with open(patch_ir, mode="r") as f:
@@ -72,8 +74,8 @@ class c2owl(Generator):
     @classmethod
     def compile(
         cls,
-        c_src_dir: str,
-        out_dir: str,
+        c_src_dir: Path,
+        out_dir: Path,
         externs: ExternInfo,
         patch_name: Optional[str] = None,
         patch_meta: Meta = Meta(),
@@ -85,41 +87,41 @@ class c2owl(Generator):
 
         tick = time.time()
 
-        out_dir = os.path.join(out_dir, "Source")
+        out_dir = Path(out_dir, "Source")
         patch_name = patch_name or "heavy"
         copyright_c = copyright_manager.get_copyright_for_c(copyright)
 
         try:
             # ensure that the output directory does not exist
-            out_dir = os.path.abspath(out_dir)
-            if os.path.exists(out_dir):
+            out_dir = out_dir.absolute()
+            if out_dir.exists():
                 shutil.rmtree(out_dir)
 
             # copy over generated C source files
             shutil.copytree(c_src_dir, out_dir)
 
             # copy over deps
-            shutil.copytree(os.path.join(os.path.dirname(__file__), "deps"), out_dir, dirs_exist_ok=True)
+            shutil.copytree(Path(os.path.dirname(__file__), "deps"), out_dir, dirs_exist_ok=True)
 
             # initialize the jinja template environment
             env = jinja2.Environment()
 
             env.loader = jinja2.FileSystemLoader(
-                os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates"))
+                Path(os.path.dirname(os.path.abspath(__file__)), "templates"))
 
             # construct jdata from ir
-            ir_dir = os.path.join(c_src_dir, "../ir")
-            patch_ir = os.path.join(ir_dir, f"{patch_name}.heavy.ir.json")
+            ir_dir = Path(c_src_dir, "../ir")
+            patch_ir = Path(ir_dir, f"{patch_name}.heavy.ir.json")
             jdata = cls.make_jdata(patch_ir)
 
             # generate OWL wrapper from template
-            owl_hpp_path = os.path.join(out_dir, f"HeavyOWL_{patch_name}.hpp")
+            owl_hpp_path = Path(out_dir, f"HeavyOWL_{patch_name}.hpp")
             with open(owl_hpp_path, "w") as f:
                 f.write(env.get_template("HeavyOwl.hpp").render(
                     jdata=jdata,
                     name=patch_name,
                     copyright=copyright_c))
-            owl_h_path = os.path.join(out_dir, "HeavyOwlConstants.h")
+            owl_h_path = Path(out_dir, "HeavyOwlConstants.h")
             with open(owl_h_path, "w") as f:
                 f.write(env.get_template("HeavyOwlConstants.h").render(
                     jdata=jdata,
@@ -131,7 +133,7 @@ class c2owl(Generator):
                 stage="c2owl",
                 in_dir=c_src_dir,
                 out_dir=out_dir,
-                out_file=os.path.basename(owl_h_path),
+                out_file=owl_h_path,
                 compile_time=time.time() - tick
             )
 

--- a/hvcc/generators/c2pdext/c2pdext.py
+++ b/hvcc/generators/c2pdext/c2pdext.py
@@ -18,7 +18,9 @@ import os
 import shutil
 import time
 import jinja2
+
 from typing import Optional
+from pathlib import Path
 
 from ..copyright import copyright_manager
 from ..filters import filter_max
@@ -35,8 +37,8 @@ class c2pdext(Generator):
     @classmethod
     def compile(
         cls,
-        c_src_dir: str,
-        out_dir: str,
+        c_src_dir: Path,
+        out_dir: Path,
         externs: ExternInfo,
         patch_name: Optional[str] = None,
         patch_meta: Meta = Meta(),
@@ -48,7 +50,7 @@ class c2pdext(Generator):
 
         tick = time.time()
 
-        out_dir = os.path.join(out_dir, "pdext")
+        out_dir = Path(out_dir, "pdext")
         receiver_list = externs.parameters.inParam
 
         copyright = copyright_manager.get_copyright_for_c(copyright)
@@ -58,7 +60,7 @@ class c2pdext(Generator):
         struct_name = f"{patch_name}_tilde"
 
         # ensure that the output directory does not exist
-        out_dir = os.path.abspath(out_dir)
+        out_dir = out_dir.absolute()
         if os.path.exists(out_dir):
             shutil.rmtree(out_dir)
 
@@ -67,10 +69,10 @@ class c2pdext(Generator):
 
         # copy over static files
         shutil.copy(
-            os.path.join(os.path.dirname(os.path.abspath(__file__)), "static", "m_pd.h"),
+            Path(Path(__file__).parent, "static", "m_pd.h"),
             f"{out_dir}/")
         shutil.copy(
-            os.path.join(os.path.dirname(os.path.abspath(__file__)), "static", "Makefile.pdlibbuilder"),
+            Path(Path(__file__).parent, "static", "Makefile.pdlibbuilder"),
             f"{out_dir}/../")
 
         try:
@@ -78,10 +80,10 @@ class c2pdext(Generator):
             env = jinja2.Environment()
             env.filters["max"] = filter_max
             env.loader = jinja2.FileSystemLoader(
-                os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates"))
+                Path(Path(__file__).parent, "templates"))
 
             # generate Pd external wrapper from template
-            pdext_path = os.path.join(out_dir, f"{ext_name}.c")
+            pdext_path = Path(out_dir, f"{ext_name}.c")
             with open(pdext_path, "w") as f:
                 f.write(env.get_template("pd_external.c").render(
                     name=patch_name,
@@ -93,7 +95,7 @@ class c2pdext(Generator):
                     copyright=copyright))
 
             # generate Makefile from template
-            pdext_path = os.path.join(out_dir, "../Makefile")
+            pdext_path = Path(out_dir, "../Makefile")
             with open(pdext_path, "w") as f:
                 f.write(env.get_template("Makefile").render(
                     name=patch_name))
@@ -102,7 +104,7 @@ class c2pdext(Generator):
                 stage="c2pdext",
                 in_dir=c_src_dir,
                 out_dir=out_dir,
-                out_file=os.path.basename(pdext_path),
+                out_file=pdext_path,
                 compile_time=time.time() - tick
             )
 

--- a/hvcc/generators/c2pdext/c2pdext.py
+++ b/hvcc/generators/c2pdext/c2pdext.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import shutil
 import time
 import jinja2
@@ -61,7 +60,7 @@ class c2pdext(Generator):
 
         # ensure that the output directory does not exist
         out_dir = out_dir.absolute()
-        if os.path.exists(out_dir):
+        if out_dir.exists():
             shutil.rmtree(out_dir)
 
         # copy over generated C source files

--- a/hvcc/generators/c2pdext/c2pdext.py
+++ b/hvcc/generators/c2pdext/c2pdext.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2021-2024 Wasted Audio
+# Copyright (C) 2021-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/generators/c2unity/c2unity.py
+++ b/hvcc/generators/c2unity/c2unity.py
@@ -18,7 +18,9 @@ import jinja2
 import os
 import shutil
 import time
+
 from typing import Optional
+from pathlib import Path
 
 from ..copyright import copyright_manager
 from ..filters import filter_templates
@@ -35,8 +37,8 @@ class c2unity(Generator):
     @classmethod
     def compile(
         cls,
-        c_src_dir: str,
-        out_dir: str,
+        c_src_dir: Path,
+        out_dir: Path,
         externs: ExternInfo,
         patch_name: Optional[str] = None,
         patch_meta: Meta = Meta(),
@@ -54,12 +56,12 @@ class c2unity(Generator):
         out_event_list = externs.events.outEvent
         table_list = externs.tables
 
-        out_dir = os.path.join(out_dir, "unity")
+        out_dir = Path(out_dir, "unity")
         patch_name = patch_name.lower() if patch_name is not None else "heavy"
 
         copyright_c = copyright_manager.get_copyright_for_c(copyright)
 
-        templates_dir = os.path.join(os.path.dirname(__file__), "templates")
+        templates_dir = Path(Path(__file__).parent, "templates")
 
         # initialise the jinja template environment
         env = jinja2.Environment()
@@ -70,12 +72,12 @@ class c2unity(Generator):
 
         try:
             # ensure that the output directory does not exist
-            out_dir = os.path.abspath(out_dir)
-            if os.path.exists(out_dir):
+            out_dir = out_dir.absolute()
+            if out_dir.exists():
                 shutil.rmtree(out_dir)
 
-            patch_src_dir = os.path.join(out_dir, "include", "Heavy")
-            if os.path.exists(patch_src_dir):
+            patch_src_dir = Path(out_dir, "include", "Heavy")
+            if patch_src_dir.exists():
                 shutil.rmtree(patch_src_dir)
             shutil.copytree(c_src_dir, patch_src_dir)
 
@@ -83,11 +85,11 @@ class c2unity(Generator):
 
             # generate files from templates
             for f in env.list_templates(filter_func=filter_templates):
-                file_path = os.path.join(out_dir, f)
-                file_path = file_path.replace("{{name}}", patch_name)
+                file_path = Path(out_dir, f)
+                file_path = Path(str(file_path).replace("{{name}}", patch_name))
 
-                if not os.path.exists(os.path.dirname(file_path)):
-                    os.makedirs(os.path.dirname(file_path))
+                if not file_path.parent.exists():
+                    os.makedirs(file_path.parent)
 
                 with open(file_path, "w") as g:
                     g.write(env.get_template(f).render(

--- a/hvcc/generators/c2unity/c2unity.py
+++ b/hvcc/generators/c2unity/c2unity.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2021-2024 Wasted Audio
+# Copyright (C) 2021-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/generators/c2wwise/c2wwise.py
+++ b/hvcc/generators/c2wwise/c2wwise.py
@@ -18,7 +18,9 @@ import os
 import shutil
 import time
 import jinja2
+
 from typing import Optional
+from pathlib import Path
 
 from ..copyright import copyright_manager
 from ..filters import filter_plugin_id
@@ -36,8 +38,8 @@ class c2wwise(Generator):
     @classmethod
     def compile(
             cls,
-            c_src_dir: str,
-            out_dir: str,
+            c_src_dir: Path,
+            out_dir: Path,
             externs: ExternInfo,
             patch_name: Optional[str] = None,
             patch_meta: Meta = Meta(),
@@ -57,13 +59,13 @@ class c2wwise(Generator):
         copyright_c = copyright_manager.get_copyright_for_c(copyright)
         copyright_xml = copyright_manager.get_copyright_for_xml(copyright)
 
-        templates_dir = os.path.join(os.path.dirname(__file__), "templates")
+        templates_dir = Path(Path(__file__).parent, "templates")
         is_source_plugin = num_input_channels == 0
         plugin_type = "Source" if is_source_plugin else "FX"
         plugin_id = filter_plugin_id(patch_name)
 
-        out_dir = os.path.join(out_dir, "wwise")
-        if not os.path.exists(out_dir):
+        out_dir = Path(out_dir, "wwise")
+        if not out_dir.exists():
             os.makedirs(out_dir)
 
         env = jinja2.Environment()
@@ -95,22 +97,22 @@ class c2wwise(Generator):
                     raise Exception("Wwise FX plugins require the same input/output channel"
                                     "configuration (i.e. [adc~ 1] -> [dac~ 1]).")
 
-            patch_src_dir = os.path.join(out_dir, "SoundEnginePlugin", "Heavy")
-            if os.path.exists(patch_src_dir):
+            patch_src_dir = Path(out_dir, "SoundEnginePlugin", "Heavy")
+            if patch_src_dir.exists():
                 shutil.rmtree(patch_src_dir)
             shutil.copytree(c_src_dir, patch_src_dir)
 
             src_ext_list = ["h", "hpp", "c", "cpp", "xml", "def", "rc", "lua", "json"]
             for f in env.list_templates(extensions=src_ext_list):
-                file_dir = os.path.join(out_dir, os.path.dirname(f))
+                file_dir = Path(out_dir, os.path.dirname(f))
                 file_name = os.path.basename(f)
 
                 file_name = file_name.replace("{{name}}", patch_name)
                 file_name = file_name.replace("{{plugin_type}}", plugin_type)
-                file_path = os.path.join(file_dir, file_name)
+                file_path = Path(file_dir, file_name)
 
-                if not os.path.exists(os.path.dirname(file_path)):
-                    os.makedirs(os.path.dirname(file_path))
+                if not file_path.parent.exists():
+                    os.makedirs(file_path.parent)
 
                 with open(file_path, "w") as g:
                     g.write(env.get_template(f).render(

--- a/hvcc/generators/c2wwise/c2wwise.py
+++ b/hvcc/generators/c2wwise/c2wwise.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2021-2024 Wasted Audio
+# Copyright (C) 2021-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/generators/copyright/copyright_manager.py
+++ b/hvcc/generators/copyright/copyright_manager.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
+# Copyright (C) 2021-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/generators/copyright/copyright_manager.py
+++ b/hvcc/generators/copyright/copyright_manager.py
@@ -14,12 +14,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
-import os
+
 from typing import Optional
+from pathlib import Path
 
 
 def get_default_copyright_text() -> str:
-    with open(os.path.join(os.path.dirname(__file__), "default_template.txt"), "r") as f:
+    with open(Path(Path(__file__).parent, "default_template.txt"), "r") as f:
         copyright = f.read().format(datetime.datetime.now().year)
     return copyright
 

--- a/hvcc/generators/ir2c/ir2c.py
+++ b/hvcc/generators/ir2c/ir2c.py
@@ -17,7 +17,6 @@
 import argparse
 import jinja2
 import json
-import os
 import shutil
 import time
 
@@ -181,7 +180,7 @@ class ir2c:
         env.filters["hvhash"] = cls.filter_hvhash
         env.filters["extern"] = cls.filter_extern
         env.loader = jinja2.FileSystemLoader(
-            Path(os.path.dirname(__file__), "templates"))
+            Path(Path(__file__).parent, "templates"))
 
         # read the hv.ir.json file
         with open(hv_ir_path, "r") as f:
@@ -299,8 +298,8 @@ class ir2c:
         #
 
         # make the output directory if necessary
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
+        if not output_dir.exists():
+            output_dir.mkdir(parents=True)
 
         # ensure that send_receive dictionary is alphabetised by the receiver key
         send_receive = OrderedDict(sorted([(k, v) for k, v in ir.control.receivers.items()], key=lambda x: x[0]))

--- a/hvcc/generators/ir2c/ir2c.py
+++ b/hvcc/generators/ir2c/ir2c.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023-2024 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/generators/ir2c/ir2c.py
+++ b/hvcc/generators/ir2c/ir2c.py
@@ -23,6 +23,7 @@ import time
 
 from collections import Counter
 from collections import OrderedDict
+from pathlib import Path
 from typing import Dict, List, Optional, Type, Union
 
 from hvcc.generators.ir2c.PrettyfyC import PrettyfyC
@@ -160,9 +161,9 @@ class ir2c:
     @classmethod
     def compile(
         cls,
-        hv_ir_path: str,
-        static_dir: str,
-        output_dir: str,
+        hv_ir_path: Path,
+        static_dir: Path,
+        output_dir: Path,
         externs: ExternInfo,
         copyright: Optional[str] = None,
         nodsp: Optional[bool] = False
@@ -180,7 +181,7 @@ class ir2c:
         env.filters["hvhash"] = cls.filter_hvhash
         env.filters["extern"] = cls.filter_extern
         env.loader = jinja2.FileSystemLoader(
-            os.path.join(os.path.dirname(__file__), "templates"))
+            Path(os.path.dirname(__file__), "templates"))
 
         # read the hv.ir.json file
         with open(hv_ir_path, "r") as f:
@@ -305,7 +306,7 @@ class ir2c:
         send_receive = OrderedDict(sorted([(k, v) for k, v in ir.control.receivers.items()], key=lambda x: x[0]))
 
         # write HeavyContext.h
-        with open(os.path.join(output_dir, f"Heavy_{name}.hpp"), "w") as f:
+        with open(Path(output_dir, f"Heavy_{name}.hpp"), "w") as f:
             f.write(env.get_template("Heavy_NAME.hpp").render(
                 name=name,
                 include_set=include_set,
@@ -318,7 +319,7 @@ class ir2c:
                 obj_header_lines=obj_header_lines))
 
         # write C++ implementation
-        with open(os.path.join(output_dir, f"Heavy_{name}.cpp"), "w") as f:
+        with open(Path(output_dir, f"Heavy_{name}.cpp"), "w") as f:
             f.write(env.get_template("Heavy_NAME.cpp").render(
                 name=name,
                 signal=ir.signal,
@@ -335,7 +336,7 @@ class ir2c:
                 nodsp=nodsp))
 
         # write C API, hv_NAME.h
-        with open(os.path.join(output_dir, f"Heavy_{name}.h"), "w") as f:
+        with open(Path(output_dir, f"Heavy_{name}.h"), "w") as f:
             f.write(env.get_template("Heavy_NAME.h").render(
                 name=name,
                 copyright=copyright,
@@ -343,17 +344,23 @@ class ir2c:
 
         # copy static files to output directory
         for f in file_set:
-            shutil.copy2(
-                src=os.path.join(static_dir, str(f)),
-                dst=os.path.join(output_dir, str(f)))
+            try:
+                shutil.copy2(
+                    src=Path(static_dir, str(f)),
+                    dst=Path(output_dir, str(f)))
+            except IOError:
+                Path.mkdir(Path(output_dir, str(f)).parent, parents=True)
+                shutil.copy2(
+                    src=Path(static_dir, str(f)),
+                    dst=Path(output_dir, str(f)))
 
         # generate HeavyIR object counter
         ir_counter = Counter([obj.type for obj in ir.objects.values()])
 
         return CompilerResp(
             stage="ir2c",
-            in_dir=os.path.dirname(hv_ir_path),
-            in_file=os.path.basename(hv_ir_path),
+            in_dir=hv_ir_path.parent,
+            in_file=hv_ir_path,
             out_dir=output_dir,
             compile_time=(time.time() - tick),
             obj_counter=ir_counter

--- a/hvcc/generators/ir2c/ir2c_perf.py
+++ b/hvcc/generators/ir2c/ir2c_perf.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023-2024 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/generators/ir2c/ir2c_perf.py
+++ b/hvcc/generators/ir2c/ir2c_perf.py
@@ -16,10 +16,10 @@
 
 import argparse
 import json
-import os
 
 from collections import Counter, defaultdict
 from typing import Dict
+from pathlib import Path
 
 from hvcc.types.IR import HeavyIRType, IRGraph
 
@@ -35,7 +35,7 @@ class ir2c_perf:
         verbose: bool = False
     ) -> Dict[str, Dict[str, float]]:
         # read the hv.ir.json file
-        with open(os.path.join(os.path.dirname(__file__), "../../core/json/heavy.ir.json"), "r") as f:
+        with open(Path(Path(__file__).parent, "../../core/json/heavy.ir.json"), "r") as f:
             HEAVY_IR_JSON = HeavyIRType(**json.load(f)).root
 
         objects: Counter = Counter()

--- a/hvcc/interpreters/pd2gui/PdGUIParser.py
+++ b/hvcc/interpreters/pd2gui/PdGUIParser.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
-import os
 
 from typing import Generator, Optional, Union
+from pathlib import Path
 
 from hvcc.interpreters.pd2hv.PdParser import PdParser
 from hvcc.types.GUI import (
@@ -22,16 +22,16 @@ class PdGUIParser(PdParser):
         self.__DOLLAR_ZERO = 1000
 
         # search paths at this graph level
-        self.search_paths: list[str] = []
+        self.search_paths: list[Path] = []
 
     def gui_from_file(
         self,
-        file_path: str,
+        file_path: Path,
         obj_args: Optional[list] = None,
         is_root: bool = True
     ) -> tuple[Union[Graph, GraphRoot], bool]:
         if is_root:
-            self.search_paths.append(os.path.dirname(file_path))
+            self.search_paths.append(file_path)
 
         file_iterator = self.get_pd_line(file_path)
         canvas_line: str = file_iterator.__next__()
@@ -57,7 +57,7 @@ class PdGUIParser(PdParser):
         file_iterator: Generator,
         canvas_line: str,
         graph_args: list,
-        pd_path: str,
+        pd_path: Path,
         is_root: bool = False
     ) -> tuple[Union[Graph, GraphRoot], bool]:
 
@@ -145,7 +145,7 @@ class PdGUIParser(PdParser):
                             # replace args with resolved args
                             line = line[:5] + obj_args
 
-                        abs_path = self.find_abstraction_path(os.path.dirname(pd_path), obj_type)
+                        abs_path = self.find_abstraction_path(pd_path.parent, obj_type)
 
                         if abs_path is not None:
                             g, gop = self.gui_from_file(abs_path, obj_args=obj_args, is_root=False)

--- a/hvcc/interpreters/pd2gui/pd2gui.py
+++ b/hvcc/interpreters/pd2gui/pd2gui.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import argparse
-import os
 import time
 
 from typing import Optional
@@ -51,7 +50,7 @@ class pd2gui:
             if not ir_dir.exists():
                 Path.mkdir(ir_dir)
 
-            gui_file = f"{os.path.splitext(pd_path.name)[0]}.gui.json"
+            gui_file = f"{pd_path.stem}.gui.json"
             gui_path = Path(ir_dir, gui_file)
             with open(gui_path, "w") as f:
                 f.write(gui_graph.model_dump_json(indent=2) + "\n")
@@ -96,12 +95,12 @@ def main() -> None:
         action="count")
     args = parser.parse_args()
 
-    args.pd_path = os.path.abspath(os.path.expanduser(args.pd_path))
-    args.ir_dir = os.path.abspath(os.path.expanduser(args.ir_dir))
+    pd_path = Path(args.pd_path).expanduser().absolute()
+    ir_dir = Path(args.ir_dir).expanduser().absolute()
 
     pd2gui.compile(
-        pd_path=args.pd_path,
-        ir_dir=args.ir_dir,
+        pd_path=pd_path,
+        ir_dir=ir_dir,
         search_paths=None,
         verbose=args.verbose)
 

--- a/hvcc/interpreters/pd2gui/pd2gui.py
+++ b/hvcc/interpreters/pd2gui/pd2gui.py
@@ -8,6 +8,7 @@ import os
 import time
 
 from typing import Optional
+from pathlib import Path
 
 from hvcc.interpreters.pd2hv.NotificationEnum import NotificationEnum
 from hvcc.interpreters.pd2gui.PdGUIParser import PdGUIParser
@@ -32,8 +33,8 @@ class pd2gui:
     @classmethod
     def compile(
         cls,
-        pd_path: str,
-        ir_dir: str,
+        pd_path: Path,
+        ir_dir: Path,
         search_paths: Optional[list] = None,
         verbose: bool = False
     ):
@@ -47,21 +48,21 @@ class pd2gui:
         try:
             gui_graph, _ = parser.gui_from_file(pd_path)
 
-            if not os.path.exists(ir_dir):
-                os.makedirs(ir_dir)
+            if not ir_dir.exists():
+                Path.mkdir(ir_dir)
 
-            gui_file = f"{os.path.splitext(os.path.basename(pd_path))[0]}.gui.json"
-            gui_path = os.path.join(ir_dir, gui_file)
+            gui_file = f"{os.path.splitext(pd_path.name)[0]}.gui.json"
+            gui_path = Path(ir_dir, gui_file)
             with open(gui_path, "w") as f:
                 f.write(gui_graph.model_dump_json(indent=2) + "\n")
 
             return CompilerResp(
                 stage="pd2gui",
                 notifs=CompilerNotif(),
-                in_dir=os.path.dirname(pd_path),
-                in_file=os.path.basename(pd_path),
+                in_dir=pd_path.parent,
+                in_file=pd_path,
                 out_dir=ir_dir,
-                out_file=gui_file,
+                out_file=gui_path,
                 compile_time=(time.time() - tick)
             )
         except Exception as e:

--- a/hvcc/interpreters/pd2gui/pd2gui.py
+++ b/hvcc/interpreters/pd2gui/pd2gui.py
@@ -1,5 +1,5 @@
 # Heavy Compiler Collection
-# Copyright (C) 2025 Wasted Audio
+# Copyright (C) 2025-2026 Wasted Audio
 #
 # SPDX-License-Identifier: GPL-3.0-only
 

--- a/hvcc/interpreters/pd2hv/HeavyGraph.py
+++ b/hvcc/interpreters/pd2hv/HeavyGraph.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/hvcc/interpreters/pd2hv/HeavyGraph.py
+++ b/hvcc/interpreters/pd2hv/HeavyGraph.py
@@ -15,8 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
-import os
+
 from typing import Optional, List, Dict
+from pathlib import Path
 
 from .PdObject import PdObject
 from .HeavyObject import HeavyObject
@@ -25,12 +26,12 @@ from .HeavyObject import HeavyObject
 class HeavyGraph(PdObject):
     def __init__(
         self,
-        hv_path: str,
+        hv_path: Path,
         obj_args: Optional[List] = None,
         pos_x: int = 0,
         pos_y: int = 0
     ) -> None:
-        super().__init__(os.path.basename(hv_path).split(".")[0], obj_args, pos_x, pos_y)
+        super().__init__(hv_path.name.split(".")[0], obj_args, pos_x, pos_y)
 
         # read the heavy graph
         with open(hv_path, "r") as f:

--- a/hvcc/interpreters/pd2hv/PdGraph.py
+++ b/hvcc/interpreters/pd2hv/PdGraph.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023-2024 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 from typing import Optional, List, Dict, Any
+from pathlib import Path
 
 from .Connection import Connection
 from .NotificationEnum import NotificationEnum
@@ -29,7 +29,7 @@ class PdGraph(PdObject):
     def __init__(
         self,
         obj_args: List,
-        pd_path: str,
+        pd_path: Path,
         pos_x: int = 0,
         pos_y: int = 0
     ) -> None:
@@ -46,7 +46,7 @@ class PdGraph(PdObject):
         self.__outlet_objects: List = []
 
         # the first search path is always the directory of this graph
-        self.__declared_paths: List = [os.path.dirname(pd_path)]
+        self.__declared_paths: List[Path] = [pd_path.parent]
 
         # heavy graph arguments (added via @hv_arg flag in #X text)
         self.hv_args: List = []
@@ -171,7 +171,7 @@ class PdGraph(PdObject):
         for o in self.__objs:
             o.validate_configuration()
 
-    def is_abstraction_on_call_stack(self, abs_path: str) -> bool:
+    def is_abstraction_on_call_stack(self, abs_path: Path) -> bool:
         """ Returns True if the given abstraction name is already on the call
             stack (i.e. it is currently being parsed). This function is used to
             detect recursion within abstractions.
@@ -238,4 +238,4 @@ class PdGraph(PdObject):
         }
 
     def __repr__(self) -> str:
-        return self.subpatch_name or os.path.basename(self.__pd_path)
+        return self.subpatch_name or str(self.__pd_path)

--- a/hvcc/interpreters/pd2hv/PdLibSignalGraph.py
+++ b/hvcc/interpreters/pd2hv/PdLibSignalGraph.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +16,7 @@
 
 import os
 from typing import List
+from pathlib import Path
 
 from .Connection import Connection
 from .HeavyObject import HeavyObject
@@ -27,7 +28,7 @@ class PdLibSignalGraph(PdGraph):
     def __init__(
         self,
         obj_args: List,
-        pd_path: str,
+        pd_path: Path,
         pos_x: int = 0,
         pos_y: int = 0
     ) -> None:

--- a/hvcc/interpreters/pd2hv/PdParser.py
+++ b/hvcc/interpreters/pd2hv/PdParser.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023-2024 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 import decimal
 import os
 import re
+
 from collections import Counter
 from collections import OrderedDict
 from pathlib import Path
@@ -47,13 +48,13 @@ from .NotificationEnum import NotificationEnum
 class PdParser:
 
     # library search paths
-    __LIB_DIR = os.path.join(os.path.dirname(__file__), "libs")
-    __HVLIB_DIR = os.path.join(os.path.dirname(__file__), "libs", "heavy")
-    __HVLIB_CONVERTED_DIR = os.path.join(os.path.dirname(__file__), "libs", "heavy_converted")
-    __PDLIB_DIR = os.path.join(os.path.dirname(__file__), "libs", "pd")
-    __ELSELIB_DIR = os.path.join(os.path.dirname(__file__), "libs", "else")
-    __CYCLONE_DIR = os.path.join(os.path.dirname(__file__), "libs", "cyclone")
-    __PDLIB_CONVERTED_DIR = os.path.join(os.path.dirname(__file__), "libs", "pd_converted")
+    __LIB_DIR = Path(os.path.dirname(__file__), "libs")
+    __HVLIB_DIR = Path(os.path.dirname(__file__), "libs", "heavy")
+    __HVLIB_CONVERTED_DIR = Path(os.path.dirname(__file__), "libs", "heavy_converted")
+    __PDLIB_DIR = Path(os.path.dirname(__file__), "libs", "pd")
+    __ELSELIB_DIR = Path(os.path.dirname(__file__), "libs", "else")
+    __CYCLONE_DIR = Path(os.path.dirname(__file__), "libs", "cyclone")
+    __PDLIB_CONVERTED_DIR = Path(os.path.dirname(__file__), "libs", "pd_converted")
 
     # detect a dollar argument in a string
     RE_DOLLAR = re.compile(r"\$(\d+)")
@@ -73,7 +74,7 @@ class PdParser:
         self.obj_counter: Counter = Counter()
 
         # search paths at this graph level
-        self.search_paths: list = []
+        self.search_paths: list[Path] = []
 
     @classmethod
     def get_supported_objects(cls) -> list:
@@ -86,7 +87,7 @@ class PdParser:
         return pd_objects
 
     @classmethod
-    def __get_hv_args(cls, pd_path: str) -> OrderedDict:
+    def __get_hv_args(cls, pd_path: Path) -> OrderedDict:
         """ Pre-parse the file for Heavy arguments, such that they are available
             as soon as a graph is created.
         """
@@ -107,7 +108,7 @@ class PdParser:
         return hv_arg_dict
 
     @classmethod
-    def get_pd_line(cls, pd_path: str) -> Generator:
+    def get_pd_line(cls, pd_path: Path) -> Generator:
         concat = ""  # concatination state
         with open(pd_path, "r") as f:
             for li in f:
@@ -133,20 +134,20 @@ class PdParser:
 
         return line
 
-    def add_absolute_search_directory(self, search_dir: str) -> bool:
-        if os.path.isdir(search_dir):
+    def add_absolute_search_directory(self, search_dir: Path) -> bool:
+        if search_dir.is_dir():
             self.search_paths.append(search_dir)
             return True
         else:
             return False
 
-    def add_relative_search_directory(self, search_dir: str) -> bool:
-        search_dir = os.path.abspath(os.path.join(
+    def add_relative_search_directory(self, search_dir: Path) -> bool:
+        search_dir = Path(
             self.search_paths[0],
-            search_dir))
+            search_dir)
         return self.add_absolute_search_directory(search_dir)
 
-    def find_abstraction_path(self, local_dir: str, abs_name: str) -> Optional[str]:
+    def find_abstraction_path(self, local_dir: Path, abs_name: str) -> Optional[Path]:
         """ Finds the full path for an abstraction.
             Checks the local directory first, then all declared paths.
         """
@@ -154,21 +155,21 @@ class PdParser:
         abs_filename = f"{abs_name}.pd"
 
         # check local directory first
-        abs_path = os.path.join(os.path.abspath(local_dir), abs_filename)
-        if os.path.isfile(abs_path):
+        abs_path = Path(local_dir.absolute(), abs_filename)
+        if abs_path.is_file():
             return abs_path
 
         # check search paths in reverse order (last added search path first)
         for d in reversed(self.search_paths):
-            abs_path = os.path.join(d, abs_filename)
-            if os.path.isfile(abs_path):
+            abs_path = Path(d, abs_filename)
+            if abs_path.is_file():
                 return abs_path
 
         return None
 
     def graph_from_file(
         self,
-        file_path: str,
+        file_path: Path,
         obj_args: Optional[list] = None,
         pos_x: int = 0,
         pos_y: int = 0,
@@ -183,7 +184,7 @@ class PdParser:
         # assumed to be the root path of the whole system
 
         if is_root:
-            self.search_paths.append(os.path.dirname(file_path))
+            self.search_paths.append(file_path.parent)
 
         file_hv_arg_dict = self.__get_hv_args(file_path)
         file_iterator = self.get_pd_line(file_path)
@@ -222,7 +223,7 @@ class PdParser:
         file_hv_arg_dict: dict[str, list[str]],
         canvas_line: str,
         graph_args: list,
-        pd_path: str,
+        pd_path: Path,
         pos_x: int = 0,
         pos_y: int = 0,
         is_root: bool = False,
@@ -317,7 +318,7 @@ class PdParser:
                                                                              range(new_size - declared_size)])
                                 obj_array = None  # done parsing the array
 
-                            # set the subpatch name
+                            # set the subpatch name)
                             g.subpatch_name = " ".join(line[5:]) if len(line) > 5 else "subpatch"
                             g = self.__create_send_recv(g, msg_send, gui_send, gui_recv)
                             return g  # pop the graph
@@ -371,7 +372,7 @@ class PdParser:
                             continue
 
                         # do we have an abstraction for this object?
-                        abs_path = self.find_abstraction_path(os.path.dirname(pd_path), obj_type)
+                        abs_path = self.find_abstraction_path(pd_path.parent, obj_type)
                         if abs_path is not None and not g.is_abstraction_on_call_stack(abs_path):
                             # ensure that infinite recursion into abstractions is not possible
                             x = self.graph_from_file(
@@ -381,27 +382,27 @@ class PdParser:
                                 is_root=False)
 
                         # is this object in lib/pd_converted?
-                        elif os.path.isfile(os.path.join(self.__PDLIB_CONVERTED_DIR, f"{obj_type}.hv.json")):
+                        elif Path(self.__PDLIB_CONVERTED_DIR, f"{obj_type}.hv.json").is_file():
                             self.obj_counter[obj_type] += 1
-                            hv_path = os.path.join(self.__PDLIB_CONVERTED_DIR, f"{obj_type}.hv.json")
+                            hv_path = Path(self.__PDLIB_CONVERTED_DIR, f"{obj_type}.hv.json")
                             x = HeavyGraph(
                                 hv_path=hv_path,
                                 obj_args=obj_args,
                                 pos_x=int(line[2]), pos_y=int(line[3]))
 
                         # is this object in lib/heavy_converted?
-                        elif os.path.isfile(os.path.join(self.__HVLIB_CONVERTED_DIR, f"{obj_type}.hv.json")):
+                        elif Path(self.__HVLIB_CONVERTED_DIR, f"{obj_type}.hv.json").is_file():
                             self.obj_counter[obj_type] += 1
-                            hv_path = os.path.join(self.__HVLIB_CONVERTED_DIR, f"{obj_type}.hv.json")
+                            hv_path = Path(self.__HVLIB_CONVERTED_DIR, f"{obj_type}.hv.json")
                             x = HeavyGraph(
                                 hv_path=hv_path,
                                 obj_args=obj_args,
                                 pos_x=int(line[2]), pos_y=int(line[3]))
 
                         # is this object in lib/pd?
-                        elif os.path.isfile(os.path.join(self.__PDLIB_DIR, f"{obj_type}.pd")):
+                        elif Path(self.__PDLIB_DIR, f"{obj_type}.pd").is_file():
                             self.obj_counter[obj_type] += 1
-                            pdlib_path = os.path.join(self.__PDLIB_DIR, f"{obj_type}.pd")
+                            pdlib_path = Path(self.__PDLIB_DIR, f"{obj_type}.pd")
 
                             # mapping of pd/lib abstraction objects to classes
                             # for checking connection validity
@@ -439,9 +440,9 @@ class PdParser:
                                     "Arguments and control connections are ignored.")
 
                         # is this object in lib/heavy?
-                        elif os.path.isfile(os.path.join(self.__HVLIB_DIR, f"{obj_type}.pd")):
+                        elif Path(self.__HVLIB_DIR, f"{obj_type}.pd").is_file():
                             self.obj_counter[obj_type] += 1
-                            hvlib_path = os.path.join(self.__HVLIB_DIR, f"{obj_type}.pd")
+                            hvlib_path = Path(self.__HVLIB_DIR, f"{obj_type}.pd")
                             x = self.graph_from_file(
                                 file_path=hvlib_path,
                                 obj_args=obj_args,
@@ -449,9 +450,19 @@ class PdParser:
                                 is_root=False)
 
                         # is this object in lib/else?
-                        elif os.path.isfile(os.path.join(self.__ELSELIB_DIR, f"{obj_type}.pd")):
+                        elif Path(self.__ELSELIB_DIR, f"{obj_type}.pd").is_file():
                             self.obj_counter[obj_type] += 1
-                            hvlib_path = os.path.join(self.__ELSELIB_DIR, f"{obj_type}.pd")
+                            hvlib_path = Path(self.__ELSELIB_DIR, f"{obj_type}.pd")
+                            x = self.graph_from_file(
+                                file_path=hvlib_path,
+                                obj_args=obj_args,
+                                pos_x=int(line[2]), pos_y=int(line[3]),
+                                is_root=False)
+
+                        # is this object in lib/cyclone?
+                        elif Path(self.__CYCLONE_DIR, f"{obj_type}.pd").is_file():
+                            self.obj_counter[obj_type] += 1
+                            hvlib_path = Path(self.__CYCLONE_DIR, f"{obj_type}.pd")
                             x = self.graph_from_file(
                                 file_path=hvlib_path,
                                 obj_args=obj_args,
@@ -459,9 +470,9 @@ class PdParser:
                                 is_root=False)
 
                         # is this object in lib? (sub-directory)
-                        elif os.path.isfile(os.path.join(self.__LIB_DIR, f"{obj_type}.pd")):
+                        elif Path(self.__LIB_DIR, f"{obj_type}.pd").is_file():
                             self.obj_counter[obj_type] += 1
-                            hvlib_path = os.path.join(self.__LIB_DIR, f"{obj_type}.pd")
+                            hvlib_path = Path(self.__LIB_DIR, f"{obj_type}.pd")
                             x = self.graph_from_file(
                                 file_path=hvlib_path,
                                 obj_args=obj_args,
@@ -528,7 +539,7 @@ class PdParser:
                                 graph=g,
                                 is_root=is_root)
                         x = self.graph_from_file(
-                            file_path=os.path.join(self.__PDLIB_DIR, f"{line[1]}.pd"),
+                            file_path=Path(self.__PDLIB_DIR, f"{line[1]}.pd"),
                             obj_args=obj_args,
                             pos_x=int(line[2]), pos_y=int(line[3]),
                             is_root=False)
@@ -595,8 +606,8 @@ class PdParser:
                                 "[declare] objects are not supported in abstractions. "
                                 "They can only be in the root canvas.")
                         elif len(line) >= 4 and line[2] == "-path":
-                            pd_parent = Path(pd_path).parent
-                            pd_search = os.path.join(pd_parent, line[3])
+                            pd_parent = pd_path.parent
+                            pd_search = Path(pd_parent, line[3])
                             did_add = self.add_relative_search_directory(pd_search)
                             if not did_add:
                                 g.add_warning(

--- a/hvcc/interpreters/pd2hv/PdParser.py
+++ b/hvcc/interpreters/pd2hv/PdParser.py
@@ -48,13 +48,13 @@ from .NotificationEnum import NotificationEnum
 class PdParser:
 
     # library search paths
-    __LIB_DIR = Path(os.path.dirname(__file__), "libs")
-    __HVLIB_DIR = Path(os.path.dirname(__file__), "libs", "heavy")
-    __HVLIB_CONVERTED_DIR = Path(os.path.dirname(__file__), "libs", "heavy_converted")
-    __PDLIB_DIR = Path(os.path.dirname(__file__), "libs", "pd")
-    __ELSELIB_DIR = Path(os.path.dirname(__file__), "libs", "else")
-    __CYCLONE_DIR = Path(os.path.dirname(__file__), "libs", "cyclone")
-    __PDLIB_CONVERTED_DIR = Path(os.path.dirname(__file__), "libs", "pd_converted")
+    __LIB_DIR = Path(Path(__file__).parent, "libs")
+    __HVLIB_DIR = Path(Path(__file__).parent, "libs", "heavy")
+    __HVLIB_CONVERTED_DIR = Path(Path(__file__).parent, "libs", "heavy_converted")
+    __PDLIB_DIR = Path(Path(__file__).parent, "libs", "pd")
+    __ELSELIB_DIR = Path(Path(__file__).parent, "libs", "else")
+    __CYCLONE_DIR = Path(Path(__file__).parent, "libs", "cyclone")
+    __PDLIB_CONVERTED_DIR = Path(Path(__file__).parent, "libs", "pd_converted")
 
     # detect a dollar argument in a string
     RE_DOLLAR = re.compile(r"\$(\d+)")
@@ -318,7 +318,7 @@ class PdParser:
                                                                              range(new_size - declared_size)])
                                 obj_array = None  # done parsing the array
 
-                            # set the subpatch name)
+                            # set the subpatch name
                             g.subpatch_name = " ".join(line[5:]) if len(line) > 5 else "subpatch"
                             g = self.__create_send_recv(g, msg_send, gui_send, gui_recv)
                             return g  # pop the graph

--- a/hvcc/interpreters/pd2hv/pd2hv.py
+++ b/hvcc/interpreters/pd2hv/pd2hv.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2023-2024 Wasted Audio
+# Copyright (C) 2023-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +18,9 @@ import argparse
 import json
 import os
 import time
+
 from typing import List, Optional
+from pathlib import Path
 
 from hvcc.interpreters.pd2hv.PdParser import PdParser
 from hvcc.types.compiler import CompilerResp, CompilerNotif
@@ -47,8 +49,8 @@ class pd2hv:
     @classmethod
     def compile(
         cls,
-        pd_path: str,
-        hv_dir: str,
+        pd_path: Path,
+        hv_dir: Path,
         search_paths: Optional[List] = None,
         verbose: bool = False,
         export_args: bool = False
@@ -74,8 +76,8 @@ class pd2hv:
                     errors=notices.errors,
                     warnings=notices.warnings
                 ),
-                in_dir=os.path.dirname(pd_path),
-                in_file=os.path.basename(pd_path),
+                in_dir=pd_path.parent,
+                in_file=pd_path,
                 compile_time=(time.time() - tick)
             )
 
@@ -83,7 +85,7 @@ class pd2hv:
             os.makedirs(hv_dir)
 
         hv_file = f"{os.path.splitext(os.path.basename(pd_path))[0]}.hv.json"
-        hv_path = os.path.join(hv_dir, hv_file)
+        hv_path = Path(hv_dir, hv_file)
         with open(hv_path, "w") as f:
             json.dump(pd_graph.to_hv(export_args=export_args), f, indent=4)
 
@@ -93,10 +95,10 @@ class pd2hv:
             notifs=CompilerNotif(
                 warnings=notices.warnings
             ),
-            in_dir=os.path.dirname(pd_path),
-            in_file=os.path.basename(pd_path),
+            in_dir=pd_path.parent,
+            in_file=pd_path,
             out_dir=hv_dir,
-            out_file=hv_file,
+            out_file=Path(hv_file),
             compile_time=(time.time() - tick)
         )
 
@@ -121,8 +123,8 @@ def main() -> None:
         action="count")
     args = parser.parse_args()
 
-    args.pd_path = os.path.abspath(os.path.expanduser(args.pd_path))
-    args.hv_dir = os.path.abspath(os.path.expanduser(args.hv_dir))
+    args.pd_path = Path(args.pd_path).expanduser().absolute()
+    args.hv_dir = Path(args.hv_dir).expanduser().absolute()
 
     result = pd2hv.compile(
         pd_path=args.pd_path,
@@ -148,7 +150,7 @@ def main() -> None:
 
     if args.verbose:
         if len(result.notifs.errors) == 0:
-            print("Heavy file written to", os.path.join(result.out_dir, result.out_file))
+            print("Heavy file written to", Path(result.out_dir, result.out_file))
         print("Total pd2hv compile time: {0:.2f}ms".format(result.compile_time * 1000))
 
 

--- a/hvcc/interpreters/pd2hv/pd2hv.py
+++ b/hvcc/interpreters/pd2hv/pd2hv.py
@@ -16,7 +16,6 @@
 
 import argparse
 import json
-import os
 import time
 
 from typing import List, Optional
@@ -81,10 +80,10 @@ class pd2hv:
                 compile_time=(time.time() - tick)
             )
 
-        if not os.path.exists(hv_dir):
-            os.makedirs(hv_dir)
+        if not hv_dir.exists():
+            hv_dir.mkdir(parents=True)
 
-        hv_file = f"{os.path.splitext(os.path.basename(pd_path))[0]}.hv.json"
+        hv_file = f"{pd_path.stem}.hv.json"
         hv_path = Path(hv_dir, hv_file)
         with open(hv_path, "w") as f:
             json.dump(pd_graph.to_hv(export_args=export_args), f, indent=4)

--- a/hvcc/main.py
+++ b/hvcc/main.py
@@ -20,6 +20,8 @@ import os
 import sys
 import time
 
+from pathlib import Path
+
 from hvcc.version import VERSION
 from hvcc.compiler import compile_dataflow
 
@@ -54,6 +56,7 @@ def main() -> bool:
         "-p",
         "--search_paths",
         nargs="+",
+        default=[],
         help="Add a list of directories to search through for abstractions.")
     parser.add_argument(
         "-n",
@@ -106,13 +109,13 @@ def main() -> bool:
     )
     args = parser.parse_args()
 
-    in_path = os.path.abspath(args.in_path)
+    in_path = Path(args.in_path).absolute()
     results = compile_dataflow(
         in_path=in_path,
-        out_dir=args.out_dir or os.path.dirname(in_path),
+        out_dir=Path(args.out_dir) or in_path.parent,
         patch_name=args.name,
         patch_meta_file=args.meta,
-        search_paths=args.search_paths,
+        search_paths=[Path(path) for path in args.search_paths],
         generators=args.gen,
         ext_generators=args.ext_gen,
         verbose=args.verbose,

--- a/hvcc/main.py
+++ b/hvcc/main.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2021-2024 Wasted Audio
+# Copyright (C) 2021-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -113,7 +113,7 @@ def main() -> bool:
         in_path=in_path,
         out_dir=Path(args.out_dir) or in_path.parent,
         patch_name=args.name,
-        patch_meta_file=args.meta,
+        patch_meta_file=Path(args.meta) if args.meta is not None else Path(),
         search_paths=[Path(path) for path in args.search_paths],
         generators=args.gen,
         ext_generators=args.ext_gen,

--- a/hvcc/main.py
+++ b/hvcc/main.py
@@ -16,7 +16,6 @@
 
 import argparse
 import json
-import os
 import sys
 import time
 
@@ -148,11 +147,11 @@ def main() -> bool:
                 r.stage, warning.message, Colours.yellow, Colours.end, i + 1))
 
     if args.results_path:
-        results_path = os.path.realpath(os.path.abspath(args.results_path))
-        results_dir = os.path.dirname(results_path)
+        results_path = Path(args.results_path).absolute().resolve()
+        results_dir = results_path.parent
 
-        if not os.path.exists(results_dir):
-            os.makedirs(results_dir)
+        if not results_dir.exists():
+            results_dir.mkdir(parents=True)
 
         with open(results_path, "w") as f:
             json.dump(results.model_dump(), f)

--- a/hvcc/types/compiler.py
+++ b/hvcc/types/compiler.py
@@ -1,5 +1,5 @@
 # Heavy Compiler Collection
-# Copyright (C) 2024 Wasted Audio
+# Copyright (C) 2024-2026 Wasted Audio
 #
 # SPDX-License-Identifier: GPL-3.0-only
 

--- a/hvcc/types/compiler.py
+++ b/hvcc/types/compiler.py
@@ -6,6 +6,7 @@
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from typing import Dict, List, Optional, Tuple
+from pathlib import Path
 
 from pydantic import BaseModel, RootModel
 
@@ -29,10 +30,10 @@ class CompilerNotif(BaseModel, arbitrary_types_allowed=True):
 class CompilerResp(BaseModel):
     stage: str
     notifs: CompilerNotif = CompilerNotif()
-    in_dir: str = ""
-    in_file: str = ""
-    out_dir: str = ""
-    out_file: str = ""
+    in_dir: Path = Path()
+    in_file: Path = Path()
+    out_dir: Path = Path()
+    out_file: Path = Path()
     compile_time: float = 0.0
     obj_counter: Counter = Counter()
     obj_perf: Dict[str, Dict[str, float]] = defaultdict(lambda: defaultdict(float))
@@ -78,8 +79,8 @@ class Generator(ABC):
     @abstractmethod
     def compile(
         cls,
-        c_src_dir: str,
-        out_dir: str,
+        c_src_dir: Path,
+        out_dir: Path,
         externs: ExternInfo,
         patch_name: Optional[str] = None,
         patch_meta: Meta = Meta(),

--- a/tests/framework/base_control.py
+++ b/tests/framework/base_control.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import platform
 import shutil
 import subprocess
@@ -95,7 +94,6 @@ class TestPdControlBase(HvBaseTest):
 
         # setup
         pd_path = Path(self.TEST_DIR, pd_file)
-        patch_name = os.path.splitext(os.path.basename(pd_path))[0]
 
         try:
             out_dir = self._run_hvcc(pd_path)
@@ -113,37 +111,42 @@ class TestPdControlBase(HvBaseTest):
         # don't delete the output dir
         # if the test fails, we can examine the output
 
-        golden_path = Path(os.path.dirname(pd_path), f"{patch_name.split('.')[0]}.golden.txt")
-        if os.path.exists(golden_path):
+        golden_path = Path(pd_path.parent, f"{pd_path.stem}.golden.txt")
+        if golden_path.exists():
             with open(golden_path, "r") as f:
                 golden = "".join(f.readlines()).splitlines()
 
                 # NO SIMD (always test this case)
                 result = self.compile_and_run(c_sources, out_dir, num_iterations, "HV_SIMD_NONE")
-                message = fail_message or self.create_fail_message(result, golden, "HV_SIMD_NONE")
+                message = fail_message or \
+                    self.create_fail_message("".join(result), "".join(golden), "HV_SIMD_NONE")
                 self.assertEqual(result, golden, message)
 
                 if platform.machine().startswith("x86"):
                     # SSE
                     result = self.compile_and_run(c_sources, out_dir, num_iterations, "HV_SIMD_SSE")
-                    message = fail_message or self.create_fail_message(result, golden, "HV_SIMD_SSE")
+                    message = fail_message or \
+                        self.create_fail_message("".join(result), "".join(golden), "HV_SIMD_SSE")
                     self.assertEqual(result, golden, message)
 
                     # SSE with FMA
                     result = self.compile_and_run(c_sources, out_dir, num_iterations, "HV_SIMD_SSE_FMA")
-                    message = fail_message or self.create_fail_message(result, golden, "HV_SIMD_SSE_FMA")
+                    message = fail_message or \
+                        self.create_fail_message("".join(result), "".join(golden), "HV_SIMD_SSE_FMA")
                     self.assertEqual(result, golden, message)
 
                     # AVX (with FMA)
                     result = self.compile_and_run(c_sources, out_dir, num_iterations, "HV_SIMD_AVX")
-                    message = fail_message or self.create_fail_message(result, golden, "HV_SIMD_AVX")
+                    message = fail_message or \
+                        self.create_fail_message("".join(result), "".join(golden), "HV_SIMD_AVX")
                     self.assertEqual(result, golden, message)
 
                 elif platform.machine().startswith("arm"):
                     # NEON
                     result = self.compile_and_run(c_sources, out_dir, num_iterations, "HV_SIMD_NEON")
-                    message = fail_message or self.create_fail_message(result, golden, "HV_SIMD_NEON")
+                    message = fail_message or \
+                        self.create_fail_message("".join(result), "".join(golden), "HV_SIMD_NEON")
                     self.assertEqual(result, golden, message)
 
         else:
-            self.fail(f"{os.path.basename(golden_path)} could not be found.")
+            self.fail(f"{golden_path.name} could not be found.")

--- a/tests/framework/base_control.py
+++ b/tests/framework/base_control.py
@@ -20,6 +20,7 @@ import shutil
 import subprocess
 
 from typing import List, Optional
+from pathlib import Path
 
 from hvcc.interpreters.pd2hv.NotificationEnum import NotificationEnum
 from tests.framework.base_test import HvBaseTest
@@ -29,8 +30,8 @@ class TestPdControlBase(HvBaseTest):
 
     def compile_and_run(
         self,
-        source_files: List[str],
-        out_dir: str,
+        source_files: List[Path],
+        out_dir: Path,
         num_iterations: int,
         flag: Optional[str] = None
     ) -> List[str]:
@@ -60,7 +61,7 @@ class TestPdControlBase(HvBaseTest):
         pd_file: str,
         expected_enum: NotificationEnum
     ) -> None:
-        pd_path = os.path.join(self.TEST_DIR, pd_file)
+        pd_path = Path(self.TEST_DIR, pd_file)
 
         try:
             self._run_hvcc(pd_path, expect_fail=True, expected_enum=expected_enum)
@@ -73,7 +74,7 @@ class TestPdControlBase(HvBaseTest):
         expected_enum: NotificationEnum
     ) -> None:
         # setup
-        pd_path = os.path.join(self.TEST_DIR, pd_file)
+        pd_path = Path(self.TEST_DIR, pd_file)
 
         try:
             self._run_hvcc(pd_path, expect_warning=True, expected_enum=expected_enum)
@@ -93,7 +94,7 @@ class TestPdControlBase(HvBaseTest):
         """
 
         # setup
-        pd_path = os.path.join(self.TEST_DIR, pd_file)
+        pd_path = Path(self.TEST_DIR, pd_file)
         patch_name = os.path.splitext(os.path.basename(pd_path))[0]
 
         try:
@@ -102,16 +103,17 @@ class TestPdControlBase(HvBaseTest):
             self.fail(str(e))
 
         # copy over additional C assets
-        c_src_dir = os.path.join(out_dir, "c")
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/test_control.c"), c_src_dir)
+        assert out_dir
+        c_src_dir = Path(out_dir, "c")
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/test_control.c"), c_src_dir)
 
         # prepare the clang command
-        c_sources = os.listdir(c_src_dir)
+        c_sources = [Path(child) for child in Path(c_src_dir).iterdir()]
 
         # don't delete the output dir
         # if the test fails, we can examine the output
 
-        golden_path = os.path.join(os.path.dirname(pd_path), f"{patch_name.split('.')[0]}.golden.txt")
+        golden_path = Path(os.path.dirname(pd_path), f"{patch_name.split('.')[0]}.golden.txt")
         if os.path.exists(golden_path):
             with open(golden_path, "r") as f:
                 golden = "".join(f.readlines()).splitlines()

--- a/tests/framework/base_control.py
+++ b/tests/framework/base_control.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2022 Wasted Audio
+# Copyright (C) 2022-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/framework/base_midi.py
+++ b/tests/framework/base_midi.py
@@ -20,6 +20,7 @@ import shutil
 import subprocess
 
 from typing import List, Optional
+from pathlib import Path
 
 from hvcc.interpreters.pd2hv.NotificationEnum import NotificationEnum
 from tests.framework.base_test import HvBaseTest
@@ -29,8 +30,8 @@ class TestPdMIDIBase(HvBaseTest):
 
     def compile_and_run(
         self,
-        source_files: List[str],
-        out_dir: str,
+        source_files: List[Path],
+        out_dir: Path,
         num_iterations: int,
         flag: Optional[str] = None
     ) -> List[str]:
@@ -40,7 +41,7 @@ class TestPdMIDIBase(HvBaseTest):
         output = subprocess.check_output([
             exe_path,
             # str(num_iterations),
-            os.path.join(out_dir, '../src/test_midi.mid')]
+            Path(out_dir, '../src/test_midi.mid')]
         ).splitlines()
 
         return [x.decode('utf-8') for x in output]
@@ -61,7 +62,7 @@ class TestPdMIDIBase(HvBaseTest):
         pd_file: str,
         expected_enum: NotificationEnum
     ) -> None:
-        pd_path = os.path.join(self.TEST_DIR, pd_file)
+        pd_path = Path(self.TEST_DIR, pd_file)
 
         try:
             self._run_hvcc(pd_path, expect_fail=True, expected_enum=expected_enum)
@@ -74,7 +75,7 @@ class TestPdMIDIBase(HvBaseTest):
         expected_enum: NotificationEnum
     ) -> None:
         # setup
-        pd_path = os.path.join(self.TEST_DIR, pd_file)
+        pd_path = Path(self.TEST_DIR, pd_file)
 
         try:
             self._run_hvcc(pd_path, expect_warning=True, expected_enum=expected_enum)
@@ -94,8 +95,8 @@ class TestPdMIDIBase(HvBaseTest):
         """
 
         # setup
-        pd_path = os.path.join(self.TEST_DIR, pd_file)
-        patch_name = os.path.splitext(os.path.basename(pd_path))[0]
+        pd_path = Path(self.TEST_DIR, pd_file)
+        patch_name = os.path.splitext(pd_path)[0]
 
         try:
             out_dir = self._run_hvcc(pd_path)
@@ -103,27 +104,28 @@ class TestPdMIDIBase(HvBaseTest):
             self.fail(str(e))
 
         # copy over additional C assets
-        c_src_dir = os.path.join(out_dir, "c")
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/test_midi.cpp"), c_src_dir)
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/midifile/include/MidiFile.h"), c_src_dir)
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/midifile/include/MidiEventList.h"), c_src_dir)
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/midifile/include/MidiEvent.h"), c_src_dir)
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/midifile/include/MidiMessage.h"), c_src_dir)
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/midifile/include/Binasc.h"), c_src_dir)
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/midifile/src/MidiFile.cpp"), c_src_dir)
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/midifile/src/MidiEventList.cpp"), c_src_dir)
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/midifile/src/MidiEvent.cpp"), c_src_dir)
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/midifile/src/MidiMessage.cpp"), c_src_dir)
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/midifile/src/Binasc.cpp"), c_src_dir)
+        assert out_dir
+        c_src_dir = Path(out_dir, "c")
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/test_midi.cpp"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/midifile/include/MidiFile.h"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/midifile/include/MidiEventList.h"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/midifile/include/MidiEvent.h"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/midifile/include/MidiMessage.h"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/midifile/include/Binasc.h"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/midifile/src/MidiFile.cpp"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/midifile/src/MidiEventList.cpp"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/midifile/src/MidiEvent.cpp"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/midifile/src/MidiMessage.cpp"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/midifile/src/Binasc.cpp"), c_src_dir)
 
         # prepare the clang command
-        c_sources = os.listdir(c_src_dir)
+        c_sources = [Path(child) for child in Path(c_src_dir).iterdir()]
 
         # don't delete the output dir
         # if the test fails, we can examine the output
 
-        golden_path = os.path.join(os.path.dirname(pd_path), f"{patch_name.split('.')[0]}.golden.txt")
-        if os.path.exists(golden_path):
+        golden_path = Path(Path(pd_path).parent, f"{patch_name.split('.')[0]}.golden.txt")
+        if golden_path.exists():
             with open(golden_path, "r") as f:
                 golden = "".join(f.readlines()).splitlines()
 

--- a/tests/framework/base_midi.py
+++ b/tests/framework/base_midi.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2022 Wasted Audio
+# Copyright (C) 2022-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/framework/base_midi.py
+++ b/tests/framework/base_midi.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import platform
 import shutil
 import subprocess
@@ -96,7 +95,6 @@ class TestPdMIDIBase(HvBaseTest):
 
         # setup
         pd_path = Path(self.TEST_DIR, pd_file)
-        patch_name = os.path.splitext(pd_path)[0]
 
         try:
             out_dir = self._run_hvcc(pd_path)
@@ -124,37 +122,42 @@ class TestPdMIDIBase(HvBaseTest):
         # don't delete the output dir
         # if the test fails, we can examine the output
 
-        golden_path = Path(Path(pd_path).parent, f"{patch_name.split('.')[0]}.golden.txt")
+        golden_path = Path(Path(pd_path).parent, f"{pd_path.stem}.golden.txt")
         if golden_path.exists():
             with open(golden_path, "r") as f:
                 golden = "".join(f.readlines()).splitlines()
 
                 # NO SIMD (always test this case)
                 result = self.compile_and_run(c_sources, out_dir, num_iterations, "HV_SIMD_NONE")
-                message = fail_message or self.create_fail_message(result, golden, "HV_SIMD_NONE")
+                message = fail_message or \
+                    self.create_fail_message("".join(result), "".join(golden), "HV_SIMD_NONE")
                 self.assertEqual(result, golden, message)
 
                 if platform.machine().startswith("x86"):
                     # SSE
                     result = self.compile_and_run(c_sources, out_dir, num_iterations, "HV_SIMD_SSE")
-                    message = fail_message or self.create_fail_message(result, golden, "HV_SIMD_SSE")
+                    message = fail_message or \
+                        self.create_fail_message("".join(result), "".join(golden), "HV_SIMD_SSE")
                     self.assertEqual(result, golden, message)
 
                     # SSE with FMA
                     result = self.compile_and_run(c_sources, out_dir, num_iterations, "HV_SIMD_SSE_FMA")
-                    message = fail_message or self.create_fail_message(result, golden, "HV_SIMD_SSE_FMA")
+                    message = fail_message or \
+                        self.create_fail_message("".join(result), "".join(golden), "HV_SIMD_SSE_FMA")
                     self.assertEqual(result, golden, message)
 
                     # AVX (with FMA)
                     result = self.compile_and_run(c_sources, out_dir, num_iterations, "HV_SIMD_AVX")
-                    message = fail_message or self.create_fail_message(result, golden, "HV_SIMD_AVX")
+                    message = fail_message or \
+                        self.create_fail_message("".join(result), "".join(golden), "HV_SIMD_AVX")
                     self.assertEqual(result, golden, message)
 
                 elif platform.machine().startswith("arm"):
                     # NEON
                     result = self.compile_and_run(c_sources, out_dir, num_iterations, "HV_SIMD_NEON")
-                    message = fail_message or self.create_fail_message(result, golden, "HV_SIMD_NEON")
+                    message = fail_message or \
+                        self.create_fail_message("".join(result), "".join(golden), "HV_SIMD_NEON")
                     self.assertEqual(result, golden, message)
 
         else:
-            self.fail(f"{os.path.basename(golden_path)} could not be found.")
+            self.fail(f"{golden_path.name} could not be found.")

--- a/tests/framework/base_signal.py
+++ b/tests/framework/base_signal.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import platform
 import shutil
 import subprocess
@@ -85,9 +84,9 @@ class TestPdSignalBase(HvBaseTest):
         pd_path = Path(self.TEST_DIR, pd_file)
 
         # setup
-        patch_name = os.path.splitext(os.path.basename(pd_path))[0]
+        patch_name = pd_path.stem
         golden_path = Path(self.TEST_DIR, f"{patch_name}.golden.wav")
-        self.assertTrue(os.path.exists(golden_path), f"File not found: {golden_path}")
+        self.assertTrue(golden_path.exists(), f"File not found: {golden_path}")
 
         try:
             out_dir = self._run_hvcc(pd_path)

--- a/tests/framework/base_signal.py
+++ b/tests/framework/base_signal.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2022 Wasted Audio
+# Copyright (C) 2022-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/framework/base_signal.py
+++ b/tests/framework/base_signal.py
@@ -21,6 +21,7 @@ import subprocess
 import numpy
 
 from typing import List, Optional
+from pathlib import Path
 
 from scipy.io import wavfile
 
@@ -31,8 +32,8 @@ class TestPdSignalBase(HvBaseTest):
 
     def compile_and_run(
         self,
-        source_files: List[str],
-        out_dir: str,
+        source_files: List[Path],
+        out_dir: Path,
         sample_rate: Optional[int] = None,
         block_size: Optional[int] = None,
         num_iterations: Optional[int] = None,
@@ -42,7 +43,7 @@ class TestPdSignalBase(HvBaseTest):
 
         # run executable
         # e.g. $ /path/heavy /path/heavy.wav 48000 480 1000
-        wav_path = os.path.join(out_dir, f"heavy.{flag}.wav")
+        wav_path = Path(out_dir, f"heavy.{flag}.wav")
         subprocess.check_output([
             exe_path,
             wav_path,
@@ -54,9 +55,9 @@ class TestPdSignalBase(HvBaseTest):
 
     def _compare_wave_output(
         self,
-        out_dir: str,
-        c_sources: List[str],
-        golden_path: str,
+        out_dir: Path,
+        c_sources: List[Path],
+        golden_path: Path,
         flag: Optional[str] = None
     ):
         # http://stackoverflow.com/questions/10580676/comparing-two-numpy-arrays-for-equality-element-wise
@@ -64,7 +65,7 @@ class TestPdSignalBase(HvBaseTest):
 
         self.compile_and_run(c_sources, out_dir, flag=flag)
 
-        [r_fs, result] = wavfile.read(os.path.join(out_dir, f"heavy.{flag}.wav"))
+        [r_fs, result] = wavfile.read(Path(out_dir, f"heavy.{flag}.wav"))
         [g_fs, golden] = wavfile.read(golden_path)
         self.assertEqual(g_fs, r_fs, f"Expected WAV sample rate of {g_fs}Hz, got {r_fs}Hz.")
         try:
@@ -81,11 +82,11 @@ class TestPdSignalBase(HvBaseTest):
         """Compiles, runs, and tests a signal patch.
         """
 
-        pd_path = os.path.join(self.TEST_DIR, pd_file)
+        pd_path = Path(self.TEST_DIR, pd_file)
 
         # setup
         patch_name = os.path.splitext(os.path.basename(pd_path))[0]
-        golden_path = os.path.join(self.TEST_DIR, f"{patch_name}.golden.wav")
+        golden_path = Path(self.TEST_DIR, f"{patch_name}.golden.wav")
         self.assertTrue(os.path.exists(golden_path), f"File not found: {golden_path}")
 
         try:
@@ -94,13 +95,14 @@ class TestPdSignalBase(HvBaseTest):
             self.fail(str(e))
 
         # copy over additional C assets
-        c_src_dir = os.path.join(out_dir, "c")
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/test_signal.c"), c_src_dir)
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/tinywav/tinywav.h"), c_src_dir)
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/tinywav/tinywav.c"), c_src_dir)
+        assert out_dir
+        c_src_dir = Path(out_dir, "c")
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/test_signal.c"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/tinywav/tinywav.h"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/tinywav/tinywav.c"), c_src_dir)
 
         # prepare the clang command
-        source_files = os.listdir(c_src_dir)
+        source_files = [Path(child) for child in Path(c_src_dir).iterdir()]
 
         # always test HV_SIMD_NONE
         self._compare_wave_output(out_dir, source_files, golden_path, "HV_SIMD_NONE")

--- a/tests/framework/base_speed.py
+++ b/tests/framework/base_speed.py
@@ -49,10 +49,9 @@ class TestPdSpeedBase(HvBaseTest):
 
     def _test_speed_patch(self, pd_file: str):
         pd_path = Path(self.TEST_DIR, pd_file)
-        # out_dir = Path(os.path.dirname(__file__), "build")
 
-        json_path = Path(os.path.dirname(pd_path), f"{os.path.basename(pd_path)[:-3]}.golden.json")
-        if os.path.exists(json_path):
+        json_path = Path(pd_path.parent, f"{pd_path.name[:-3]}.golden.json")
+        if json_path.exists():
             with open(json_path, "r") as f:
                 golden = json.load(f)
         else:
@@ -81,8 +80,8 @@ class TestPdSpeedBase(HvBaseTest):
             tock = golden["usPerBlock"]["HV_SIMD_SSE"]
             percent_difference = 100.0 * (tick - tock) / tock
             self.assertTrue(percent_difference < self.__PERCENT_THRESHOLD,
-                            f"{os.path.basename(pd_path)} has become {percent_difference:g}% slower @ {tick}us/block.")
+                            f"{pd_path.name} has become {percent_difference:g}% slower @ {tick}us/block.")
             if (percent_difference < -self.__PERCENT_THRESHOLD):
-                print(f"{os.path.basename(pd_path)} has become significantly faster: {percent_difference:g}%")
+                print(f"{pd_path.name} has become significantly faster: {percent_difference:g}%")
         else:
             print(tick)

--- a/tests/framework/base_speed.py
+++ b/tests/framework/base_speed.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2022 Wasted Audio
+# Copyright (C) 2022-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/framework/base_speed.py
+++ b/tests/framework/base_speed.py
@@ -20,6 +20,7 @@ import shutil
 import subprocess
 
 from typing import List, Optional
+from pathlib import Path
 
 from tests.framework.base_test import HvBaseTest
 
@@ -28,8 +29,8 @@ class TestPdSpeedBase(HvBaseTest):
 
     def compile_and_run(
         self,
-        source_files: List[str],
-        out_dir: str,
+        source_files: List[Path],
+        out_dir: Path,
         sample_rate: Optional[int] = None,
         block_size: Optional[int] = None,
         num_iterations: Optional[int] = None,
@@ -47,10 +48,10 @@ class TestPdSpeedBase(HvBaseTest):
         return float(result)
 
     def _test_speed_patch(self, pd_file: str):
-        pd_path = os.path.join(self.TEST_DIR, pd_file)
-        # out_dir = os.path.join(os.path.dirname(__file__), "build")
+        pd_path = Path(self.TEST_DIR, pd_file)
+        # out_dir = Path(os.path.dirname(__file__), "build")
 
-        json_path = os.path.join(os.path.dirname(pd_path), f"{os.path.basename(pd_path)[:-3]}.golden.json")
+        json_path = Path(os.path.dirname(pd_path), f"{os.path.basename(pd_path)[:-3]}.golden.json")
         if os.path.exists(json_path):
             with open(json_path, "r") as f:
                 golden = json.load(f)
@@ -62,12 +63,13 @@ class TestPdSpeedBase(HvBaseTest):
         except Exception as e:
             self.fail(str(e))
 
-        c_src_dir = os.path.join(out_dir, "c")
+        assert out_dir
+        c_src_dir = Path(out_dir, "c")
 
         # copy additional source
-        shutil.copy2(os.path.join(self.SCRIPT_DIR, "src/test_speed.c"), c_src_dir)
+        shutil.copy2(Path(self.SCRIPT_DIR, "src/test_speed.c"), c_src_dir)
 
-        c_sources = [os.path.join(c_src_dir, c) for c in os.listdir(c_src_dir) if c.endswith(".c")]
+        c_sources = [Path(c_src_dir, c) for c in os.listdir(c_src_dir) if c.endswith(".c")]
 
         tick = self.compile_and_run(c_sources, out_dir,
                                     golden.get("samplerate", 48000.0),

--- a/tests/framework/base_test.py
+++ b/tests/framework/base_test.py
@@ -15,12 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import jinja2
-import os
 import shutil
 import subprocess
 import unittest
 
 from typing import List, Optional
+from pathlib import Path
 
 import hvcc
 
@@ -42,23 +42,23 @@ class HvBaseTest(unittest.TestCase):
 
     def setUp(self):
         self.env = jinja2.Environment()
-        self.env.loader = jinja2.FileSystemLoader(os.path.join(
-            os.path.dirname(__file__),
+        self.env.loader = jinja2.FileSystemLoader(Path(
+            Path(__file__).parent,
             "template"))
 
     def _run_hvcc(
         self,
-        pd_path: str,
+        pd_path: Path,
         expect_warning: bool = False,
         expect_fail: bool = False,
         expected_enum: NotificationEnum = NotificationEnum.EMPTY
-    ) -> Optional[str]:
+    ) -> Optional[Path]:
         """Run hvcc on a Pd file. Returns the output directory.
         """
 
         # clean default output directories
-        out_dir = os.path.join(self.SCRIPT_DIR, "build")
-        if os.path.exists(out_dir):
+        out_dir = Path(self.SCRIPT_DIR, "build")
+        if out_dir.exists():
             shutil.rmtree(out_dir)
 
         hvcc_results = hvcc.compile_dataflow(pd_path, out_dir, verbose=False)
@@ -97,30 +97,30 @@ class HvBaseTest(unittest.TestCase):
 
     def _compile_and_run(
         self,
-        source_files: List[str],
-        out_dir: str,
+        source_files: List[Path],
+        out_dir: Path,
         flag: Optional[str] = None
     ):
-        exe_path = os.path.join(out_dir, "heavy")
+        exe_path = Path(out_dir, "heavy")
 
         # template Makefile
         # NOTE(mhroth): assertions are NOT turned off (help to catch errors)
-        makefile_path = os.path.join(out_dir, "c", "Makefile")
+        makefile_path = Path(out_dir, "c", "Makefile")
         with open(makefile_path, "w") as f:
             f.write(self.env.get_template("Makefile").render(
                 simd_flags=simd_flags[flag or "HV_SIMD_NONE"],
-                source_files=source_files,
+                source_files=[str(f) for f in source_files],
                 out_path=exe_path))
 
         # run the compile command
-        subprocess.check_output(["make", "-C", os.path.dirname(makefile_path), "-j"])
+        subprocess.check_output(["make", "-C", Path(makefile_path).parent, "-j"])
 
         return exe_path
 
     def _compile_and_run_clang(
         self,
-        source_files: List[str],
-        out_dir: str,
+        source_files: List[Path],
+        out_dir: Path,
         flag: Optional[str] = None,
     ):
         flag = flag or "HV_SIMD_NONE"
@@ -136,7 +136,7 @@ class HvBaseTest(unittest.TestCase):
             "-Werror", "-Wno-#warnings", "-Wno-unused-function",
             "-lm"]
 
-        exe_path = os.path.join(out_dir, "heavy")
+        exe_path = Path(out_dir, "heavy")
 
         # run the compile command
         cmd = ["clang"] + c_flags + source_files + ["-o", exe_path]  # + ['-v']

--- a/tests/framework/base_test.py
+++ b/tests/framework/base_test.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2022 Wasted Audio
+# Copyright (C) 2022-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/integration/test_pd2gui.py
+++ b/tests/integration/test_pd2gui.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
-import os
 import json
 
 from pathlib import Path
@@ -13,7 +12,7 @@ from hvcc.version import VERSION
 
 
 class TestPdGuiParser:
-    SCRIPT_DIR = os.path.dirname(__file__)
+    SCRIPT_DIR = Path(__file__).parent
 
     def _test_gui_patch(
         self,
@@ -30,11 +29,11 @@ class TestPdGuiParser:
         if response.notifs.has_error:
             raise Exception(response.notifs.errors[0])
 
-        gui_path = Path(self.SCRIPT_DIR, "ir", os.path.splitext(path)[0] + ".gui.json")
+        gui_path = Path(self.SCRIPT_DIR, "ir", Path(path).stem + ".gui.json")
         with open(gui_path, "r") as f:
             gui = json.loads(f.read())
 
-        expected_path = Path(os.path.splitext(source_path)[0] + ".golden.json")
+        expected_path = Path(source_path.parent, source_path.stem + ".golden.json")
         with open(expected_path, "r") as f:
             expected = json.loads(f.read())
             expected['version'] = VERSION

--- a/tests/integration/test_pd2gui.py
+++ b/tests/integration/test_pd2gui.py
@@ -6,6 +6,8 @@
 import os
 import json
 
+from pathlib import Path
+
 from hvcc.interpreters.pd2gui.pd2gui import pd2gui
 from hvcc.version import VERSION
 
@@ -17,8 +19,8 @@ class TestPdGuiParser:
         self,
         path: str
     ) -> None:
-        source_path = os.path.join(self.SCRIPT_DIR, "data", path)
-        ir_path = os.path.join(self.SCRIPT_DIR, "ir")
+        source_path = Path(self.SCRIPT_DIR, "data", path)
+        ir_path = Path(self.SCRIPT_DIR, "ir")
 
         response = pd2gui.compile(
             pd_path=source_path,
@@ -28,11 +30,11 @@ class TestPdGuiParser:
         if response.notifs.has_error:
             raise Exception(response.notifs.errors[0])
 
-        gui_path = os.path.join(self.SCRIPT_DIR, "ir", os.path.splitext(path)[0] + ".gui.json")
+        gui_path = Path(self.SCRIPT_DIR, "ir", os.path.splitext(path)[0] + ".gui.json")
         with open(gui_path, "r") as f:
             gui = json.loads(f.read())
 
-        expected_path = os.path.join(os.path.splitext(source_path)[0] + ".golden.json")
+        expected_path = Path(os.path.splitext(source_path)[0] + ".golden.json")
         with open(expected_path, "r") as f:
             expected = json.loads(f.read())
             expected['version'] = VERSION

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
-import os
 import unittest
 
 from pathlib import Path

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -18,13 +18,15 @@ import argparse
 import os
 import unittest
 
+from pathlib import Path
+
 from hvcc.interpreters.pd2hv.NotificationEnum import NotificationEnum
 from tests.framework.base_control import TestPdControlBase
 
 
 class TestPdControlPatches(TestPdControlBase):
-    SCRIPT_DIR = os.path.dirname(__file__)
-    TEST_DIR = os.path.join(os.path.dirname(__file__), "pd", "control")
+    SCRIPT_DIR = Path(__file__).parent
+    TEST_DIR = Path(Path(__file__).parent, "pd", "control")
 
     def test_abs(self):
         self._test_control_patch("test-abs.pd")
@@ -103,7 +105,7 @@ class TestPdControlPatches(TestPdControlBase):
         self._test_control_patch("test-exp.pd")
 
     def test_extern_names_capitals(self):
-        self._test_control_patch_expect_error("test-extern_names_capitals.pd", None)
+        self._test_control_patch_expect_error("test-extern_names_capitals.pd", NotificationEnum.EMPTY)
 
     def test_empty_patch(self):
         self._test_control_patch("test-empty_patch.pd")
@@ -335,7 +337,7 @@ def main():
         "pd_path",
         help="The path to the Pd file to read.")
     args = parser.parse_args()
-    if os.path.exists(args.pd_path):
+    if Path(args.pd_path).exists():
         test_control = TestPdControlPatches()
         result = test_control._test_control_patch(pd_file=args.pd_path)
         print(result)

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2022 Wasted Audio
+# Copyright (C) 2022-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_control_expr.py
+++ b/tests/test_control_expr.py
@@ -14,8 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
-import os
 # import unittest
+
+from pathlib import Path
 
 from tests.framework.base_control import TestPdControlBase
 
@@ -25,8 +26,8 @@ class TestPdControlExprPatches(TestPdControlBase):
         Consider all available expressions: https://pd.iem.sh/objects/expr~/
     """
 
-    SCRIPT_DIR = os.path.dirname(__file__)
-    TEST_DIR = os.path.join(os.path.dirname(__file__), "pd", "control_expr")
+    SCRIPT_DIR = Path(__file__).parent
+    TEST_DIR = Path(Path(__file__).parent, "pd", "control_expr")
 
     # Math operations
 
@@ -191,7 +192,7 @@ def main():
         "pd_path",
         help="The path to the Pd file to read.")
     args = parser.parse_args()
-    if os.path.exists(args.pd_path):
+    if Path(args.pd_path).exists:
         result = TestPdControlExprPatches._test_control_patch(args.pd_path)
         print(result)
     else:

--- a/tests/test_control_expr.py
+++ b/tests/test_control_expr.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2022-2025 Daniel Billotte, Wasted Audio
+# Copyright (C) 2022-2025 Daniel Billotte
+# Copyright (C) 2022-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -13,16 +13,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import unittest
 import subprocess
+
+from pathlib import Path
 
 from tests.framework.base_midi import TestPdMIDIBase
 
 
 class TestPdMIDIPatches(TestPdMIDIBase):
-    SCRIPT_DIR = os.path.dirname(__file__)
-    TEST_DIR = os.path.join(os.path.dirname(__file__), "pd", "midi")
+    SCRIPT_DIR = Path(__file__).parent
+    TEST_DIR = Path(Path(__file__).parent, "pd", "midi")
 
     @classmethod
     def setUpClass(cls):

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Wasted Audio
+# Copyright (C) 2022-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2022 Wasted Audio
+# Copyright (C) 2022-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -17,12 +17,14 @@
 import argparse
 import os
 
+from pathlib import Path
+
 from tests.framework.base_signal import TestPdSignalBase
 
 
 class TestPdSignalPatches(TestPdSignalBase):
-    SCRIPT_DIR = os.path.dirname(__file__)
-    TEST_DIR = os.path.join(os.path.dirname(__file__), "pd", "signal")
+    SCRIPT_DIR = Path(__file__).parent
+    TEST_DIR = Path(Path(__file__).parent, "pd", "signal")
 
     def test_line(self):
         self._test_signal_patch("test-line.pd")
@@ -64,8 +66,8 @@ def main():
 
     out_dir = TestPdSignalPatches._run_hvcc(args.pd_path)
 
-    c_src_dir = os.path.join(out_dir, "c")
-    c_sources = [os.path.join(c_src_dir, c) for c in os.listdir(c_src_dir) if c.endswith(".c")]
+    c_src_dir = Path(out_dir, "c")
+    c_sources = [Path(c_src_dir, c) for c in os.listdir(c_src_dir) if c.endswith(".c")]
 
     wav_path = TestPdSignalPatches.compile_and_run(
         out_dir,

--- a/tests/test_signal_cyclone.py
+++ b/tests/test_signal_cyclone.py
@@ -14,16 +14,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
-import os
 import unittest
+
+from pathlib import Path
 
 from tests.framework.base_control import TestPdControlBase
 
 
 class TestPdSignalCyclonePatches(TestPdControlBase):
 
-    SCRIPT_DIR = os.path.dirname(__file__)
-    TEST_DIR = os.path.join(os.path.dirname(__file__), "pd", "signal_cyclone")
+    SCRIPT_DIR = Path(__file__).parent
+    TEST_DIR = Path(Path(__file__).parent, "pd", "signal_cyclone")
 
     # Math operations
 
@@ -83,7 +84,7 @@ def main():
         "pd_path",
         help="The path to the Pd file to read.")
     args = parser.parse_args()
-    if os.path.exists(args.pd_path):
+    if Path(args.pd_path).exists():
         result = TestPdSignalCyclonePatches._test_control_patch(args.pd_path)
         print(result)
     else:

--- a/tests/test_signal_cyclone.py
+++ b/tests/test_signal_cyclone.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2025 Daniel Billotte, Wasted Audio
+# Copyright (C) 2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_signal_expr.py
+++ b/tests/test_signal_expr.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2022-2025 Daniel Billotte, Wasted Audio
+# Copyright (C) 2022-2025 Daniel Billotte
+# Copyright (C) 2022-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_signal_expr.py
+++ b/tests/test_signal_expr.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
-import os
 import unittest
 
 from tests.framework.base_control import TestPdControlBase

--- a/tests/test_signal_expr.py
+++ b/tests/test_signal_expr.py
@@ -18,6 +18,7 @@ import os
 import unittest
 
 from tests.framework.base_control import TestPdControlBase
+from pathlib import Path
 
 
 class TestPdControlExprPatches(TestPdControlBase):
@@ -25,8 +26,8 @@ class TestPdControlExprPatches(TestPdControlBase):
         Consider all available expressions: https://pd.iem.sh/objects/expr~/
     """
 
-    SCRIPT_DIR = os.path.dirname(__file__)
-    TEST_DIR = os.path.join(os.path.dirname(__file__), "pd", "signal_expr")
+    SCRIPT_DIR = Path(__file__).parent
+    TEST_DIR = Path(Path(__file__).parent, "pd", "signal_expr")
 
     # Math operations
 
@@ -199,8 +200,8 @@ def main():
         "pd_path",
         help="The path to the Pd file to read.")
     args = parser.parse_args()
-    if os.path.exists(args.pd_path):
-        result = TestPdControlExprPatches._test_control_patch(args.pd_path)
+    if Path(args.pd_path).exists():
+        result = TestPdControlExprPatches._test_control_patch(Path(args.pd_path))
         print(result)
     else:
         print(f"Pd file path '{args.pd_path}' doesn't exist")

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
+# Copyright (C) 2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -13,8 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import unittest
+
+from pathlib import Path
 
 from tests.framework.base_speed import TestPdSpeedBase
 
@@ -23,8 +24,8 @@ raise unittest.SkipTest()
 
 class TestPdPatches(TestPdSpeedBase):
 
-    SCRIPT_DIR = os.path.dirname(__file__)
-    TEST_DIR = os.path.join(os.path.dirname(__file__), "pd", "speed")
+    SCRIPT_DIR = Path(__file__).parent
+    TEST_DIR = Path(Path(__file__).parent, "pd", "speed")
     # test results cannot be more than 2% slower than the golden value
     __PERCENT_THRESHOLD = 2.0
 

--- a/tests/test_speed_avx.py
+++ b/tests/test_speed_avx.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
-# Copyright (C) 2022 Wasted Audio
+# Copyright (C) 2022-2026 Wasted Audio
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_speed_avx.py
+++ b/tests/test_speed_avx.py
@@ -20,6 +20,8 @@ import subprocess
 import time
 import unittest
 
+from pathlib import Path
+
 SCRIPT_DIR = os.path.dirname(__file__)
 
 raise unittest.SkipTest()
@@ -30,43 +32,43 @@ def compile_and_run_patch(pd_file):
     patch_name = os.path.splitext(os.path.basename(pd_file))[0]
 
     # clean any existing output directories
-    out_dir = os.path.abspath(os.path.join(SCRIPT_DIR, "./build"))
-    if os.path.exists(out_dir):
+    out_dir = Path(SCRIPT_DIR, "./build").absolute()
+    if out_dir.exists():
         shutil.rmtree(out_dir)
 
     # create new output directories and copy over assets
-    c_src_dir = os.path.join(out_dir, "src")
+    c_src_dir = Path(out_dir, "src")
     os.makedirs(c_src_dir)
-    asm_dir = os.path.join(out_dir, "asm")
+    asm_dir = Path(out_dir, "asm")
     os.makedirs(asm_dir)
-    shutil.copy2(os.path.join(SCRIPT_DIR, "test_speed.c"), c_src_dir)
+    shutil.copy2(Path(SCRIPT_DIR, "test_speed.c"), c_src_dir)
 
     # pd2hv
-    py_script = os.path.join(SCRIPT_DIR, "../hvcc/interpreters/pd2hv/pd2hv.py")
+    py_script = Path(SCRIPT_DIR, "../hvcc/interpreters/pd2hv/pd2hv.py")
     cmd = (["python", py_script, pd_file, out_dir, "-v"])
     print(subprocess.check_output(cmd))
 
     # hv2ir
-    py_script = os.path.join(SCRIPT_DIR, "../hvcc/core/hv2ir/hv2ir.py")
-    hv_file = os.path.join(out_dir, f"{patch_name}.hv.json")
-    ir_file = os.path.join(out_dir, f"{patch_name}.ir.hv.json")
+    py_script = Path(SCRIPT_DIR, "../hvcc/core/hv2ir/hv2ir.py")
+    hv_file = Path(out_dir, f"{patch_name}.hv.json")
+    ir_file = Path(out_dir, f"{patch_name}.ir.hv.json")
     cmd = (["python", py_script, hv_file, "--hv_ir_path", ir_file])
     print(subprocess.check_output(cmd))
 
     # ir2c
-    ir2c_dir = os.path.join(SCRIPT_DIR, "../hvcc/generators/ir2c/")
-    cmd = (["python", os.path.join(ir2c_dir, "ir2c.py"), ir_file,
-            "--static_dir", os.path.join(ir2c_dir, "static"),
-            # "--template_path", os.path.join(ir2c_dir, "template"),
+    ir2c_dir = Path(SCRIPT_DIR, "../hvcc/generators/ir2c/")
+    cmd = (["python", Path(ir2c_dir, "ir2c.py"), ir_file,
+            "--static_dir", Path(ir2c_dir, "static"),
+            # "--template_path", Path(ir2c_dir, "template"),
             "--output_dir", c_src_dir,
             "--verbose"])
     print(subprocess.check_output(cmd))
 
     # ir2c-perf
-    cmd = (["python", os.path.join(ir2c_dir, "ir2c_perf.py"), ir_file])
+    cmd = (["python", Path(ir2c_dir, "ir2c_perf.py"), ir_file])
     print(subprocess.check_output(cmd))
 
-    c_sources = [os.path.join(c_src_dir, c) for c in os.listdir(c_src_dir) if c.endswith(".c")]
+    c_sources = [Path(c_src_dir, c) for c in os.listdir(c_src_dir) if c.endswith(".c")]
     flags = [
         "-msse", "-msse2", "-msse3", "-mssse3", "-msse4.1", "-msse4.2", "-mavx",
         "-O3", "-march=native",
@@ -78,12 +80,12 @@ def compile_and_run_patch(pd_file):
     # generate assembly
     print(f"Assembly output directory: {asm_dir}/")
     for c_src in c_sources:
-        asm_out = os.path.join(asm_dir, f"{os.path.splitext(os.path.basename(c_src))[0]}.s")
+        asm_out = Path(asm_dir, f"{os.path.splitext(os.path.basename(c_src))[0]}.s")
         cmd = ["clang"] + flags + ["-S", "-O3", "-mllvm", "--x86-asm-syntax=intel", c_src, "-o", asm_out]
         subprocess.check_output(cmd)
 
     # compile app
-    exe_file = os.path.join(out_dir, "heavy")
+    exe_file = Path(out_dir, "heavy")
     cmd = ["clang", "-Werror"] + flags + c_sources + ["-o", exe_file, "-lm"]
 
     start_time = time.time()
@@ -106,11 +108,11 @@ class TestPdPatches(unittest.TestCase):
     def test_speed_avx(self):
         self.maxDiff = None
         # collect all test patches in script directory
-        patches_dir = os.path.join(SCRIPT_DIR, "pd", "speed")
+        patches_dir = Path(SCRIPT_DIR, "pd", "speed")
         test_patches = []
         for f in os.listdir(patches_dir):
             if f.startswith("test-") and f.endswith(".pd"):
-                test_patches.append(os.path.join(patches_dir, f))
+                test_patches.append(Path(patches_dir, f))
 
         # compile, run and compare patches
         for pd_file in test_patches:

--- a/tests/test_speed_avx.py
+++ b/tests/test_speed_avx.py
@@ -22,14 +22,14 @@ import unittest
 
 from pathlib import Path
 
-SCRIPT_DIR = os.path.dirname(__file__)
+SCRIPT_DIR = Path(__file__).parent
 
 raise unittest.SkipTest()
 
 
 def compile_and_run_patch(pd_file):
     # setup
-    patch_name = os.path.splitext(os.path.basename(pd_file))[0]
+    patch_name = pd_file.stem
 
     # clean any existing output directories
     out_dir = Path(SCRIPT_DIR, "./build").absolute()
@@ -38,9 +38,9 @@ def compile_and_run_patch(pd_file):
 
     # create new output directories and copy over assets
     c_src_dir = Path(out_dir, "src")
-    os.makedirs(c_src_dir)
+    c_src_dir.mkdir(parents=True)
     asm_dir = Path(out_dir, "asm")
-    os.makedirs(asm_dir)
+    asm_dir.mkdir(parents=True)
     shutil.copy2(Path(SCRIPT_DIR, "test_speed.c"), c_src_dir)
 
     # pd2hv
@@ -80,7 +80,7 @@ def compile_and_run_patch(pd_file):
     # generate assembly
     print(f"Assembly output directory: {asm_dir}/")
     for c_src in c_sources:
-        asm_out = Path(asm_dir, f"{os.path.splitext(os.path.basename(c_src))[0]}.s")
+        asm_out = Path(asm_dir, f"{Path(c_src).stem}.s")
         cmd = ["clang"] + flags + ["-S", "-O3", "-mllvm", "--x86-asm-syntax=intel", c_src, "-o", asm_out]
         subprocess.check_output(cmd)
 
@@ -97,7 +97,7 @@ def compile_and_run_patch(pd_file):
     result = subprocess.check_output([exe_file]).split("\n")
 
     # # clean up
-    # if os.path.exists(out_dir):
+    # if out_dir.exists():
     #     shutil.rmtree(out_dir)
 
     return result

--- a/tests/unit/daisy/test_integration.py
+++ b/tests/unit/daisy/test_integration.py
@@ -1,6 +1,5 @@
 import unittest
 
-from os import path
 from pathlib import Path
 
 from hvcc.generators.c2daisy.json2daisy import generate_header_from_name

--- a/tests/unit/daisy/test_integration.py
+++ b/tests/unit/daisy/test_integration.py
@@ -1,12 +1,14 @@
 import unittest
 
 from os import path
+from pathlib import Path
 
 from hvcc.generators.c2daisy.json2daisy import generate_header_from_name
 
 
 # Grabbing the absolute path to test data
-data_path = path.join(path.dirname(path.abspath(__file__)), 'data')
+data_path = Path(Path(__file__).parent, 'data')
+print(data_path)
 
 
 class TestIntegration(unittest.TestCase):
@@ -14,35 +16,35 @@ class TestIntegration(unittest.TestCase):
     def test_patch(self):
         self.maxDiff = None
         header, info = generate_header_from_name('patch')
-        with open(path.join(data_path, 'integration', 'expected_patch.h'), 'r') as file:
+        with open(Path(data_path, 'integration', 'expected_patch.h'), 'r') as file:
             self.assertEqual(header, file.read(), 'The output string should match "expected_patch.h" exactly')
 
     def test_patch_init(self):
         self.maxDiff = None
         header, info = generate_header_from_name('patch_init')
-        with open(path.join(data_path, 'integration', 'expected_patch_init.h'), 'r') as file:
+        with open(Path(data_path, 'integration', 'expected_patch_init.h'), 'r') as file:
             self.assertEqual(header, file.read(), 'The output string should match "expected_patch_init.h" exactly')
 
     def test_petal(self):
         self.maxDiff = None
         header, info = generate_header_from_name('petal')
-        with open(path.join(data_path, 'integration', 'expected_petal.h'), 'r') as file:
+        with open(Path(data_path, 'integration', 'expected_petal.h'), 'r') as file:
             self.assertEqual(header, file.read(), 'The output string should match "expected_petal.h" exactly')
 
     def test_petal_125b_sm(self):
         self.maxDiff = None
         header, info = generate_header_from_name('petal_125b_sm')
-        with open(path.join(data_path, 'integration', 'expected_petal_125b_sm.h'), 'r') as file:
+        with open(Path(data_path, 'integration', 'expected_petal_125b_sm.h'), 'r') as file:
             self.assertEqual(header, file.read(), 'The output string should match "expected_petal_125b_sm.h" exactly')
 
     def test_pod(self):
         self.maxDiff = None
         header, info = generate_header_from_name('pod')
-        with open(path.join(data_path, 'integration', 'expected_pod.h'), 'r') as file:
+        with open(Path(data_path, 'integration', 'expected_pod.h'), 'r') as file:
             self.assertEqual(header, file.read(), 'The output string should match "expected_pod.h" exactly')
 
     def test_field(self):
         self.maxDiff = None
         header, info = generate_header_from_name('field')
-        with open(path.join(data_path, 'integration', 'expected_field.h'), 'r') as file:
+        with open(Path(data_path, 'integration', 'expected_field.h'), 'r') as file:
             self.assertEqual(header, file.read(), 'The output string should match "expected_field.h" exactly')


### PR DESCRIPTION
Long time coming. Pathlib is supported since py34 and it makes a lot of function signatures more readable.