### PR TITLE
Support docs versioning

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,16 @@
 name: Publish Docs
 on:
   push:
-    branches:
-      - develop
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version label to deploy (e.g. 0.15.0)"
+        required: true
+      alias:
+        description: "Optional alias (e.g. latest, rc)"
+        required: false
 permissions:
   contents: write
 jobs:
@@ -10,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
@@ -24,5 +34,35 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material
-      - run: mkdocs gh-deploy --force
+      - run: pip install mkdocs-material mike
+      - name: Deploy versioned docs
+        env:
+          VERSION_INPUT: ${{ github.event.inputs.version }}
+          ALIAS_INPUT: ${{ github.event.inputs.alias }}
+        run: |
+          if [ -n "${VERSION_INPUT}" ]; then
+            VERSION="${VERSION_INPUT}"
+            if [ -n "${ALIAS_INPUT}" ]; then
+              ALIAS="${ALIAS_INPUT}"
+            else
+              ALIAS="latest"
+            fi
+          elif [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+            ALIAS="latest"
+          else
+            echo "No version provided and ref is not a tag; aborting."
+            exit 1
+          fi
+
+          if [ -n "${ALIAS}" ] && [ "${ALIAS}" != "${VERSION}" ]; then
+            echo "Deploying docs version '${VERSION}' with alias '${ALIAS}'"
+            mike deploy --push --update-aliases "${VERSION}" "${ALIAS}"
+          else
+            echo "Deploying docs version '${VERSION}' without alias"
+            mike deploy --push "${VERSION}"
+          fi
+
+          if [ "${ALIAS}" = "latest" ]; then
+            mike set-default --push latest
+          fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,8 @@
 name: Publish Docs
 on:
   push:
+    branches:
+      - develop
     tags:
       - "v*"
   workflow_dispatch:
@@ -50,8 +52,11 @@ jobs:
           elif [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             VERSION="${GITHUB_REF_NAME#v}"
             ALIAS="latest"
+          elif [ "${GITHUB_REF_NAME}" = "develop" ]; then
+            VERSION="develop"
+            ALIAS=""
           else
-            echo "No version provided and ref is not a tag; aborting."
+            echo "No version provided and ref is not a tag or develop; aborting."
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,10 @@ Please use English for all communications to include as many people as possible.
 - Write unit, integration or end-to-end tests as appropriate to your feature or bug-fix.
 - Review and update the [Changelog](CHANGELOG.md) and [Documentation](/docs/). Your changes may affect sections of these documents.
   - You can run the documentation locally using `mkdocs serve`.
+  - For versioned docs previews, run `mike serve`.
+  - Release docs are versioned by the docs workflow:
+    - tags matching `v*` (for example `v0.15.0`) publish that version and update the `latest` alias
+    - manual dispatch can publish an explicit version and optional alias when needed
 - If your feature is large, or has a significant impact on other parts of the code, write an [Architecture Decision Record](/docs/ADRs/) describing the consideractions related to the change.
 
 ### Git best practices

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Heavy Compiler Collection
 repo_url: https://github.com/Wasted-Audio/hvcc
 repo_name: Wasted-Audio/hvcc
+site_url: https://wasted-audio.github.io/hvcc/
 theme:
   name: material
   features:
@@ -12,6 +13,10 @@ theme:
     scheme: slate  # Dark mode support
   logo: img/logo-compressed.svg
   favicon: img/favicon.ico
+
+extra:
+  version:
+    provider: mike
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
Here's how it looks locally:

<img width="1532" height="1015" alt="Screenshot 2026-04-20 at 09 38 58" src="https://github.com/user-attachments/assets/1f9c8129-8ca1-4e5a-81f2-41f398ad67c8" />

The workflow automatically publishes new versions when a new tag is pushed
After merging this, I believe we'll need to manually push older versions before they show up in the publised docs. Like this, perhaps:

```
pip install mkdocs-material mike
mike deploy 0.13.4 --ignore-remote-status
mike deploy 0.14.0 --ignore-remote-status
mike deploy --update-aliases 0.15.0 latest --ignore-remote-status
mike set-default latest --ignore-remote-status
git push -f origin gh-pages
```