### PR TITLE
Fix multi-array subpatch parsing

### DIFF
--- a/hvcc/interpreters/pd2hv/PdParser.py
+++ b/hvcc/interpreters/pd2hv/PdParser.py
@@ -239,6 +239,28 @@ class PdParser:
         """
         obj_array: Optional[HeavyObject] = None  # an #A (table) object which is currently being parsed
 
+        def finalize_array(array: Optional[HeavyObject]) -> None:
+            if array is None:
+                return
+
+            declared_size = array.obj_dict["size"]
+            values_size = len(array.obj_dict["values"])
+            if declared_size != values_size:
+                new_size = max(declared_size, values_size)
+                array.add_warning(
+                    "Table \"{0}\" was declared as having {1} values, "
+                    "but {2} were supplied. It will be resized to {3} "
+                    "values (any unsupplied values will be zeroed).".format(
+                        array.obj_dict["name"],
+                        declared_size,
+                        values_size,
+                        new_size))
+                array.obj_dict["size"] = new_size
+                if new_size < declared_size:
+                    array.obj_dict["values"] = array.obj_dict["values"][:new_size]
+                else:
+                    array.obj_dict["values"].extend([0.0 for _ in range(new_size - declared_size)])
+
         g = pd_graph_class(graph_args, pd_path, pos_x, pos_y)
 
         msg_send: dict = {}
@@ -296,27 +318,8 @@ class PdParser:
                                     pos_y=int(line[3]))
                             return x  # return a Heavy object instead of a graph
                         else:
-                            # are we restoring an array object?
-                            # do some final sanity checks
                             if obj_array is not None:
-                                declared_size = obj_array.obj_dict["size"]
-                                values_size = len(obj_array.obj_dict["values"])
-                                if declared_size != values_size:
-                                    new_size = max(declared_size, values_size)
-                                    obj_array.add_warning(
-                                        "Table \"{0}\" was declared as having {1} values, "
-                                        "but {2} were supplied. It will be resized to {3} "
-                                        "values (any unsupplied values will be zeroed).".format(
-                                            obj_array.obj_dict["name"],
-                                            declared_size,
-                                            values_size,
-                                            new_size))
-                                    obj_array.obj_dict["size"] = new_size
-                                    if new_size < declared_size:
-                                        obj_array.obj_dict["values"] = obj_args["values"][:new_size]
-                                    else:
-                                        obj_array.obj_dict["values"].extend([0.0 for _ in
-                                                                             range(new_size - declared_size)])
+                                finalize_array(obj_array)
                                 obj_array = None  # done parsing the array
 
                             # set the subpatch name
@@ -556,7 +559,8 @@ class PdParser:
                                 gui_recv[index] = obj_args[8]
 
                     elif line[1] == "array":
-                        assert obj_array is None, "#X array object is already being parsed."
+                        if obj_array is not None:
+                            finalize_array(obj_array)
                         # array names can have dollar arguments in them.
                         # ensure that they are resolved
                         table_def = self.__resolve_object_args(

--- a/hvcc/interpreters/pd2hv/PdParser.py
+++ b/hvcc/interpreters/pd2hv/PdParser.py
@@ -239,10 +239,7 @@ class PdParser:
         """
         obj_array: Optional[HeavyObject] = None  # an #A (table) object which is currently being parsed
 
-        def finalize_array(array: Optional[HeavyObject]) -> None:
-            if array is None:
-                return
-
+        def finalize_array(array: HeavyObject) -> None:
             declared_size = array.obj_dict["size"]
             values_size = len(array.obj_dict["values"])
             if declared_size != values_size:
@@ -560,6 +557,8 @@ class PdParser:
 
                     elif line[1] == "array":
                         if obj_array is not None:
+                            # A new array starts before "#X restore", so finish
+                            # the current table before parsing the next one.
                             finalize_array(obj_array)
                         # array names can have dollar arguments in them.
                         # ensure that they are resolved

--- a/tests/unit/test_pd_parser.py
+++ b/tests/unit/test_pd_parser.py
@@ -1,27 +1,68 @@
+from pathlib import Path
+from textwrap import dedent
+
 from hvcc.interpreters.pd2hv.PdParser import PdParser
 
 
-def test_multiple_arrays_in_subpatch_parse_without_metadata_errors(tmp_path):
-    pd_path = tmp_path / "multi_array_subpatch.pd"
+def parse_subpatch(tmp_path: Path, array_lines: str):
+    pd_path = tmp_path / "array_subpatch.pd"
     pd_path.write_text(
-        """#N canvas 827 239 734 565 12;
-#N canvas 0 0 450 250 (subpatch) 0;
-#X array array1 100 float 2;
-#A color 0;
-#A width 2;
-#X array array2 100 float 0;
-#A color 0;
-#A width 1;
-#X coords 0 1 100 -1 200 140 1;
-#X restore 308 106 graph;
-"""
+        "#N canvas 827 239 734 565 12;\n"
+        "#N canvas 0 0 450 250 (subpatch) 0;\n"
+        f"{dedent(array_lines)}"
+        "#X coords 0 1 100 -1 200 140 1;\n"
+        "#X restore 308 106 graph;\n"
     )
 
     graph = PdParser().graph_from_file(pd_path)
-
     assert not graph.get_notices().has_error
+    return [obj for obj in graph.get_objects()[0].get_objects() if obj.obj_type == "table"]
 
-    subpatch = graph.get_objects()[0]
-    tables = [obj for obj in subpatch.get_objects() if obj.obj_type == "table"]
+
+def test_subpatch_parses_single_array(tmp_path: Path):
+    tables = parse_subpatch(
+        tmp_path,
+        """\
+        #X array array1 4 float 2;
+        #A color 0;
+        #A width 2;
+        """,
+    )
+
+    assert [table.obj_dict["name"] for table in tables] == ["array1"]
+
+
+def test_subpatch_parses_multiple_arrays(tmp_path: Path):
+    tables = parse_subpatch(
+        tmp_path,
+        """\
+        #X array array1 100 float 2;
+        #A color 0;
+        #A width 2;
+        #X array array2 100 float 0;
+        #A color 0;
+        #A width 1;
+        """,
+    )
 
     assert [table.obj_dict["name"] for table in tables] == ["array1", "array2"]
+
+
+def test_subpatch_parses_multi_line_arrays(tmp_path: Path):
+    tables = parse_subpatch(
+        tmp_path,
+        """\
+        #X array array1 4 float 2;
+        #A 0 0 1;
+        #A 2 2 3;
+        #X array array2 4 float 0;
+        #A 0 4 5;
+        #A 2 6 7;
+        """,
+    )
+
+    assert [table.obj_dict["name"] for table in tables] == ["array1", "array2"]
+    assert [table.obj_dict["values"] for table in tables] == [
+        [0.0, 1.0, 2.0, 3.0],
+        [4.0, 5.0, 6.0, 7.0],
+    ]

--- a/tests/unit/test_pd_parser.py
+++ b/tests/unit/test_pd_parser.py
@@ -1,0 +1,27 @@
+from hvcc.interpreters.pd2hv.PdParser import PdParser
+
+
+def test_multiple_arrays_in_subpatch_parse_without_metadata_errors(tmp_path):
+    pd_path = tmp_path / "multi_array_subpatch.pd"
+    pd_path.write_text(
+        """#N canvas 827 239 734 565 12;
+#N canvas 0 0 450 250 (subpatch) 0;
+#X array array1 100 float 2;
+#A color 0;
+#A width 2;
+#X array array2 100 float 0;
+#A color 0;
+#A width 1;
+#X coords 0 1 100 -1 200 140 1;
+#X restore 308 106 graph;
+"""
+    )
+
+    graph = PdParser().graph_from_file(pd_path)
+
+    assert not graph.get_notices().has_error
+
+    subpatch = graph.get_objects()[0]
+    tables = [obj for obj in subpatch.get_objects() if obj.obj_type == "table"]
+
+    assert [table.obj_dict["name"] for table in tables] == ["array1", "array2"]


### PR DESCRIPTION
## Summary

- finalize the current Pd array parse when another `#X array` starts in the same subpatch
- keep later `#A color` / `#A width` metadata attached to the correct array instead of reporting parser errors
- add a parser regression for the multi-array subpatch case from #373

Fixes #373.

## Validation

- `.venv/bin/python -m pytest tests/unit/test_pd_parser.py -q` (`1 passed`)
- `.venv/bin/python -m pytest tests/unit -q` (`18 passed`)
- `.venv/bin/python -m pytest tests/test_control.py::TestPdControlPatches::test_array -q` (`1 passed`)
- `.venv/bin/python -m flake8 hvcc/interpreters/pd2hv/PdParser.py tests/unit/test_pd_parser.py`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --exit-code 1`

I did not run the full `tox` matrix locally.

AI assistance was used to prepare this patch; the behavior and validation above were checked locally.
